### PR TITLE
added ability to add attributes to the CollectionBuilder

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "5.1.5",
+      "version": "5.2.0",
       "commands": [
         "fantomas"
       ]

--- a/src/Fabulous.Benchmarks/Benchmarks.fs
+++ b/src/Fabulous.Benchmarks/Benchmarks.fs
@@ -57,7 +57,9 @@ module DiffingAttributes =
 
     let update msg model =
         match msg with
-        | IncBy amount -> { model with counter = model.counter + amount }
+        | IncBy amount ->
+            { model with
+                counter = model.counter + amount }
 
     let rec viewInner depth counter =
         Stack() {
@@ -108,7 +110,9 @@ module DiffingSmallScalars =
 
     let update msg model =
         match msg with
-        | IncBy amount -> { model with counter = model.counter + amount }
+        | IncBy amount ->
+            { model with
+                counter = model.counter + amount }
 
     let rec viewBoxedInner depth counter =
         // this is to emulate changing value only once per 5 updates

--- a/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
@@ -468,7 +468,7 @@ module MemoTests =
                 | Btn -> View.lazy' (fun i -> Button(string i, Change).automationId("btn")) model
                 | Lbl -> View.lazy' (fun i -> Label(string i).automationId("label")) model
             }
-                
+
 
         [<Test>]
         let Test () =

--- a/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
@@ -549,7 +549,9 @@ module SmallScalars =
 
     let update msg model =
         match msg with
-        | Inc value -> { model with value = model.value + value }
+        | Inc value ->
+            { model with
+                value = model.value + value }
 
     let view model =
         InlineNumericBag(model.value, model.value + 1UL, float(model.value + 2UL))

--- a/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
@@ -115,8 +115,8 @@ module SimpleStackTests =
             |> List.map(fun (id_, text_) -> if id = id_ then (id, text) else (id_, text_))
 
     let view model =
-        (Stack() { yield! model |> List.map(fun (id, text) -> Label(text).automationId(id.ToString())) })
-            .automationId("stack")
+        Stack().automationId("stack") { yield! model |> List.map(fun (id, text) -> Label(text).automationId(id.ToString())) }
+
 
 
     let init () = []
@@ -194,13 +194,13 @@ module ComputationExpressionTest =
     let Condition () =
         let view model =
             // requires implemented "Zero"
-            (Stack() {
+            Stack().automationId("stack") {
                 if (model % 2 = 0) then
                     Label("label").automationId("label")
                 else
                     Button("btn", Inc).automationId("btn")
-            })
-                .automationId("stack")
+            }
+
 
 
         let instance = StatefulWidget.mkSimpleView (fun () -> 0) update view |> Run.Instance
@@ -463,12 +463,12 @@ module MemoTests =
                 | Lbl -> Btn
 
         let view model =
-            (Stack() {
+            Stack().automationId("stack") {
                 match model with
                 | Btn -> View.lazy' (fun i -> Button(string i, Change).automationId("btn")) model
                 | Lbl -> View.lazy' (fun i -> Label(string i).automationId("label")) model
-            })
-                .automationId("stack")
+            }
+                
 
         [<Test>]
         let Test () =

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -86,6 +86,14 @@ module TestUI_Widgets =
             this.AddScalar(Attributes.Automation.AutomationId.WithValue(value))
 
         [<Extension>]
+        static member inline automationId<'msg, 'marker, 'itemMarker when 'marker :> IMarker>
+            (
+                this: CollectionBuilder<'msg, 'marker, 'itemMarker>,
+                value: string
+            ) =
+            this.AddScalar(Attributes.Automation.AutomationId.WithValue(value))
+
+        [<Extension>]
         static member inline textColor<'msg, 'marker when 'marker :> TextMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
             this.AddScalar(Attributes.TextStyle.TextColor.WithValue(value))
 
@@ -157,7 +165,7 @@ module TestUI_Widgets =
                 _: CollectionBuilder<'msg, 'marker, IMarker>,
                 x: WidgetBuilder<'msg, 'itemMarker>
             ) : Content<'msg> =
-            { Widgets = MutStackArray1.One(x.Compile()) }
+            CollectionBuilder.yieldImpl x
 
         [<Extension>]
         static member inline Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
@@ -165,7 +173,7 @@ module TestUI_Widgets =
                 _: CollectionBuilder<'msg, 'marker, IMarker>,
                 x: WidgetBuilder<'msg, Memo.Memoized<'itemMarker>>
             ) : Content<'msg> =
-            { Widgets = MutStackArray1.One(x.Compile()) }
+            CollectionBuilder.yieldImpl x
 
         [<Extension>]
         static member inline YieldFrom<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -178,11 +178,6 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
         member inline x.AddScalar(attr: ScalarAttribute) =
             CollectionBuilder<'msg, 'marker, 'itemMarker>(x.WidgetKey, StackList.add(&x.Scalars, attr), x.Attr)
 
-
-
-
-
-
     end
 
 module CollectionBuilder =

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -182,6 +182,7 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
 
 
 
+
     end
 
 module CollectionBuilder =

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -177,13 +177,16 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
         [<EditorBrowsable(EditorBrowsableState.Never)>]
         member inline x.AddScalar(attr: ScalarAttribute) =
             CollectionBuilder<'msg, 'marker, 'itemMarker>(x.WidgetKey, StackList.add(&x.Scalars, attr), x.Attr)
-    
-    
+
+
+
+
 
     end
 
 module CollectionBuilder =
-    let inline yieldImpl (builder: WidgetBuilder<'msg, 'itemMarker>): Content<'msg> = { Widgets = MutStackArray1.One(builder.Compile()) }
+    let inline yieldImpl (builder: WidgetBuilder<'msg, 'itemMarker>) : Content<'msg> =
+        { Widgets = MutStackArray1.One(builder.Compile()) }
 
 [<Struct>]
 type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker> =

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -173,7 +173,17 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
                 res <- x.Combine(res, f t)
 
             res
+
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline x.AddScalar(attr: ScalarAttribute) =
+            CollectionBuilder<'msg, 'marker, 'itemMarker>(x.WidgetKey, StackList.add(&x.Scalars, attr), x.Attr)
+    
+    
+
     end
+
+module CollectionBuilder =
+    let inline yieldImpl (builder: WidgetBuilder<'msg, 'itemMarker>): Content<'msg> = { Widgets = MutStackArray1.One(builder.Compile()) }
 
 [<Struct>]
 type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker> =

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -30,7 +30,7 @@ module View =
             let fnWithBoxing (msg: obj) =
                 let oldFn = unbox<obj -> obj> oldAttr.Value
 
-                if typeof<'newMsg>.IsAssignableFrom (msg.GetType()) then
+                if typeof<'newMsg>.IsAssignableFrom(msg.GetType()) then
                     box msg
                 else
                     oldFn msg |> unbox<'oldMsg> |> fn |> box
@@ -39,7 +39,7 @@ module View =
 
         let defaultWith () =
             let mappedFn (msg: obj) =
-                if typeof<'newMsg>.IsAssignableFrom (msg.GetType()) then
+                if typeof<'newMsg>.IsAssignableFrom(msg.GetType()) then
                     box msg
                 else
                     unbox<'oldMsg> msg |> fn |> box

--- a/src/Fabulous/WidgetDiff.fs
+++ b/src/Fabulous/WidgetDiff.fs
@@ -114,11 +114,7 @@ and [<Struct; NoComparison; NoEquality>] WidgetDiff =
           WidgetCollectionChanges = WidgetCollectionChanges(prevWidgetCollectionAttributes, next.WidgetCollectionAttributes, canReuseView, compareScalars) }
 
 and [<Struct; NoComparison; NoEquality>] ScalarChanges
-    (
-        prev: ScalarAttribute[] voption,
-        next: ScalarAttribute[] voption,
-        compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison
-    ) =
+    (prev: ScalarAttribute[] voption, next: ScalarAttribute[] voption, compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison) =
     member _.GetEnumerator() =
         ScalarChangesEnumerator(EnumerationMode.fromOptions prev next, compareScalars)
 
@@ -155,10 +151,7 @@ and [<Struct; NoComparison; NoEquality>] WidgetCollectionItemChanges
 
 // enumerators
 and [<Struct; IsByRefLike>] ScalarChangesEnumerator
-    (
-        mode: EnumerationMode<ScalarAttribute>,
-        compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison
-    ) =
+    (mode: EnumerationMode<ScalarAttribute>, compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison) =
 
     [<DefaultValue(false)>]
     val mutable private current: ScalarChange


### PR DESCRIPTION
- This is backward compatible change (purely additive)
- Added `AddScalar` to the `CollectionBuilder`
- Added `CollectionBuilder.yieldImpl` helper to not expose `MutStackArray1` as much, I think it will be easier to document
- We already had a usage in tests for such an API `Stack().automationId()`, thus no new tests were needed
- Note that now you have a choice either to add a property to `CollectionBuilder` or `WiddgetBuilder` or both. Meaning that we can control precisely at what point attributes can be declared

```fsharp
// this will add "(Stack() {...}).automationId("id)"
[<Extension>]
static member inline automationId<'msg, 'marker when 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
    this.AddScalar(Attributes.Automation.AutomationId.WithValue(value))

// this will add "Stack().automationId("id) {...}"
[<Extension>]
static member inline automationId<'msg, 'marker, 'itemMarker when 'marker :> IMarker>
    (
        this: CollectionBuilder<'msg, 'marker, 'itemMarker>,
        value: string
    ) =
    this.AddScalar(Attributes.Automation.AutomationId.WithValue(value))
```