### PR TITLE
Fix a NullReferenceException when applying `View.map` to a view using `Unit` Msg type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes_
+### Fixed
+- Fix a NullReferenceException when applying `View.map` to a view using `Unit` Msg type (https://github.com/fabulous-dev/Fabulous/pull/1037) 
 
 ## [2.2.0] - 2023-01-24
 

--- a/src/Fabulous.Tests/Fabulous.Tests.fsproj
+++ b/src/Fabulous.Tests/Fabulous.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="APISketchTests\APISketchTests.fs" />
     <Compile Include="Generators.fs" />
     <Compile Include="AttributesTests.fs" />
+    <Compile Include="ViewTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />

--- a/src/Fabulous.Tests/ViewTests.fs
+++ b/src/Fabulous.Tests/ViewTests.fs
@@ -1,0 +1,36 @@
+namespace Fabulous.Tests
+
+open Fabulous
+open Fabulous.StackAllocatedCollections.StackList
+open NUnit.Framework
+open FsCheck.NUnit
+
+type ITestControl =
+    interface
+    end
+
+module TestControl =
+    let WidgetKey: WidgetKey = 1
+
+type Msg = ChildMsg of unit
+
+[<TestFixture>]
+type ``View helper functions tests``() =
+
+    /// Test: https://github.com/fabulous-dev/Fabulous/pull/1037
+    [<Test>]
+    member _.``Mapping a WidgetBuilder with Unit Msg to another Msg is supported``() =
+        let widgetBuilder =
+            WidgetBuilder<unit, ITestControl>(TestControl.WidgetKey, AttributesBundle(StackList.empty(), ValueNone, ValueNone))
+
+        let mapMsg (oldMsg: unit) = ChildMsg oldMsg
+
+        let mappedWidgetBuilder = View.map mapMsg widgetBuilder
+
+        Assert.AreEqual(widgetBuilder.Key, mappedWidgetBuilder.Key)
+
+        let struct (scalars, _, _) = mappedWidgetBuilder.Attributes
+        let scalars = StackList.toArray &scalars
+
+        Assert.AreEqual(1, scalars.Length)
+        Assert.AreEqual(MapMsg.MapMsg.Key, scalars[0].Key)

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -30,7 +30,7 @@ module View =
             let fnWithBoxing (msg: obj) =
                 let oldFn = unbox<obj -> obj> oldAttr.Value
 
-                if typeof<'newMsg>.IsAssignableFrom(msg.GetType()) then
+                if msg <> null && typeof<'newMsg>.IsAssignableFrom(msg.GetType()) then
                     box msg
                 else
                     oldFn msg |> unbox<'oldMsg> |> fn |> box
@@ -39,7 +39,7 @@ module View =
 
         let defaultWith () =
             let mappedFn (msg: obj) =
-                if typeof<'newMsg>.IsAssignableFrom(msg.GetType()) then
+                if msg <> null && typeof<'newMsg>.IsAssignableFrom(msg.GetType()) then
                     box msg
                 else
                     unbox<'oldMsg> msg |> fn |> box


### PR DESCRIPTION
When the `'msg` type is `unit`, `View.map` crashes with a NullReferenceException.
This is due to `()` being represented as `null`.

This PR improves `View.map` by checking if the `msg` is `null` before checking for `msg.GetType()`.

```fs
let view model: WidgetBuilder<unit, IFabButton> =
    Button("Click me", ()) // here we pass a Unit as Msg

type ParentMsg =
     | ChildMsg of unit

let parentView model =
    VStack() {
         View.map ChildMsg (view model) // Will crash because msg = () = null
    }
```