### PR TITLE
Add support for float32 properties

### DIFF
--- a/src/Fabulous.Tests/AttributesTests.fs
+++ b/src/Fabulous.Tests/AttributesTests.fs
@@ -20,6 +20,12 @@ type AttributesTests() =
         Assert.AreEqual(value, decoded)
 
     [<Property>]
+    member _.``Encoding then decoding a float32 should return an identical float32``(value: float32) =
+        let encoded = SmallScalars.Float32.encode value
+        let decoded = SmallScalars.Float32.decode encoded
+        Assert.AreEqual(value, decoded)
+
+    [<Property>]
     member _.``Encoding then decoding an int should return an identical int``(value: int) =
         let encoded = SmallScalars.Int.encode value
         let decoded = SmallScalars.Int.decode encoded

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -35,6 +35,13 @@ module SmallScalars =
         let inline decode (encoded: uint64) : float =
             encoded |> int64 |> BitConverter.Int64BitsToDouble
 
+    module Float32 =
+        let inline encode (v: float32) : uint64 =
+            v |> float |> BitConverter.DoubleToInt64Bits |> uint64
+
+        let inline decode (encoded: uint64) : float32 =
+            encoded |> int64 |> BitConverter.Int64BitsToDouble |> float32
+
     // TODO is there a better conversion algorithm?
     module Int =
         let inline encode (v: int) : uint64 = uint64 v

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -69,6 +69,10 @@ type SmallScalarExtensions() =
         this.WithValue(value, SmallScalars.Float.encode)
 
     [<Extension>]
+    static member inline WithValue(this: SmallScalarAttributeDefinition<float32>, value) =
+        this.WithValue(value, SmallScalars.Float32.encode)
+
+    [<Extension>]
     static member inline WithValue(this: SmallScalarAttributeDefinition<int>, value) =
         this.WithValue(value, SmallScalars.Int.encode)
 


### PR DESCRIPTION
Initially to support float32 properties in Xamarin.Forms, see this [PR](https://github.com/fabulous-dev/Fabulous.XamarinForms/pull/35).