### PR TITLE
Ensure view function is only called on UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes_
+### Changed
+- `view` function now runs only on the UI thread by @TimLariviere (https://github.com/fabulous-dev/Fabulous/pull/1043)
 
 ## [2.3.1] - 2023-05-22
 

--- a/src/Fabulous/Runners.fs
+++ b/src/Fabulous/Runners.fs
@@ -219,8 +219,7 @@ module ViewAdapters =
                             Reconciler.update canReuseView (ValueSome prevWidget) currentWidget node
                         with ex ->
                             if not(exceptionHandler ex) then
-                                reraise()
-                    )
+                                reraise())
             with ex ->
                 if not(exceptionHandler ex) then
                     reraise()

--- a/src/Fabulous/Runners.fs
+++ b/src/Fabulous/Runners.fs
@@ -206,20 +206,21 @@ module ViewAdapters =
         member _.OnStateChanged(args) =
             try
                 if args.Key = stateKey then
-                    let state = unbox args.NewState
-
-                    let prevWidget = _widget
-                    let currentWidget = (view state).Compile()
-                    _widget <- currentWidget
-
-                    let node = getViewNode _root
-
                     syncAction(fun () ->
                         try
+                            let state = unbox args.NewState
+
+                            let prevWidget = _widget
+                            let currentWidget = (view state).Compile()
+                            _widget <- currentWidget
+
+                            let node = getViewNode _root
+
                             Reconciler.update canReuseView (ValueSome prevWidget) currentWidget node
                         with ex ->
                             if not(exceptionHandler ex) then
-                                reraise())
+                                reraise()
+                    )
             with ex ->
                 if not(exceptionHandler ex) then
                     reraise()


### PR DESCRIPTION
For performance reasons, we have decided to let `init`, `update` and `view` run on whatever thread the message was dispatched from. This is because the MVU functions don't access the UI itself, Fabulous deals with it exclusively during reconcilation so we only synchronize back to the UI thread during diffing to avoid the perf hit of jumping threads.

But if we need to access some information related to the UI inside the `view` function (such as the safe area margins), it requires access to the UI thread, otherwise it could crash.

This PR ensures that the view function is called only on the UI thread to avoid those issues.