### PR TITLE
Remove dot before accessing indexed property

### DIFF
--- a/src/Fabulous/Array.fs
+++ b/src/Fabulous/Array.fs
@@ -42,7 +42,7 @@ module ArraySlice =
         // noop if we don't have enough space
         if (used + by <= arr.Length) then
             for i = used + by - 1 downto int by do
-                arr.[i] <- arr.[i - by]
+                arr[i] <- arr[i - by]
 
         arr
 
@@ -50,7 +50,7 @@ module Array =
     let inline appendOne (v: 'v) (arr: 'v array) =
         let res = Array.zeroCreate(arr.Length + 1)
         Array.blit arr 0 res 0 arr.Length
-        res.[arr.Length] <- v
+        res[arr.Length] <- v
         res
 
     /// This is insertion sort that is O(n*n) but it performs better
@@ -63,13 +63,13 @@ module Array =
 
         for i in [ 1 .. N - 1 ] do
             for j = i downto 1 do
-                let key = getKey attrs.[j]
-                let prevKey = getKey attrs.[j - 1]
+                let key = getKey attrs[j]
+                let prevKey = getKey attrs[j - 1]
 
                 if key < prevKey then
-                    let temp = attrs.[j]
-                    attrs.[j] <- attrs.[j - 1]
-                    attrs.[j - 1] <- temp
+                    let temp = attrs[j]
+                    attrs[j] <- attrs[j - 1]
+                    attrs[j - 1] <- temp
 
         attrs
 
@@ -127,18 +127,18 @@ module StackAllocatedCollections =
                         let used =
                             match data.size % 3us with
                             | 0us -> // copy 3 items
-                                arr.[size - 1] <- v2
-                                arr.[size - 2] <- v1
-                                arr.[size - 3] <- v0
+                                arr[size - 1] <- v2
+                                arr[size - 2] <- v1
+                                arr[size - 3] <- v0
                                 3
                             | 1us ->
                                 // copy 1 item
-                                arr.[size - 1] <- v0
+                                arr[size - 1] <- v0
                                 1
                             | 2us ->
                                 // copy 2 item
-                                arr.[size - 1] <- v1
-                                arr.[size - 2] <- v0
+                                arr[size - 1] <- v1
+                                arr[size - 2] <- v0
                                 2
                             | _ -> 0
 
@@ -149,9 +149,9 @@ module StackAllocatedCollections =
                             match leftToCopy with
                             | Empty -> i <- -1
                             | Filled((v0, v1, v2), before) ->
-                                arr.[i] <- v2
-                                arr.[i - 1] <- v1
-                                arr.[i - 2] <- v0
+                                arr[i] <- v2
+                                arr[i - 1] <- v1
+                                arr[i - 2] <- v0
                                 i <- i - 3
                                 leftToCopy <- before
 
@@ -305,7 +305,7 @@ module StackAllocatedCollections =
                     | 1 -> v1
                     | _ -> v2
 
-            | Many arr -> arr.[index]
+            | Many arr -> arr[index]
 
 
         let find (test: 'v -> bool) (arr: StackArray3<'v> inref) : 'v =
@@ -417,7 +417,7 @@ module StackAllocatedCollections =
             | Many struct (count, mutArr) ->
                 if mutArr.Length > (int count) then
                     // we can fit it in
-                    mutArr.[int count] <- value
+                    mutArr[int count] <- value
                     Many(count + 1us, mutArr)
                 else
                     // in this branch we reached the capacity of the array, thus needs to grow
@@ -430,7 +430,7 @@ module StackAllocatedCollections =
                         Array.zeroCreate(grow mutArr.Length)
 
                     Array.blit mutArr 0 res 0 mutArr.Length
-                    res.[countInt] <- value
+                    res[countInt] <- value
                     Many(count + 1us, res)
 
         let inline toArray (arr: T<'v> inref) : 'v array =
@@ -442,7 +442,7 @@ module StackAllocatedCollections =
         let inline fromArray (arr: 'v array) : T<'v> =
             match arr.Length with
             | 0 -> Empty
-            | 1 -> One arr.[0]
+            | 1 -> One arr[0]
             | size -> Many(uint16 size, arr)
 
         let inline toArraySlice (arr: T<'v> inref) : ArraySlice<'v> voption =
@@ -470,7 +470,7 @@ module StackAllocatedCollections =
                     if arr.Length >= (int used) + 1 then
                         // it means that arr can fit one more element
                         let arr = ArraySlice.shiftByMut &sliceB 1us
-                        arr.[0] <- av
+                        arr[0] <- av
                         Many(used + 1us, arr)
                     else
                         // we need to allocate a new one more
@@ -478,7 +478,7 @@ module StackAllocatedCollections =
                         let newArr = Array.zeroCreate(grow arr.Length)
 
                         Array.blit arr 0 newArr 1 (int used)
-                        newArr.[0] <- av
+                        newArr[0] <- av
                         Many(used + 1us, newArr)
 
                 | Many sliceA ->
@@ -633,7 +633,7 @@ module StackAllocatedCollections =
             let encodedValue = ((uint16 op <<< 14) &&& opMask)
             let encodedValue = encodedValue ||| (index &&& valueMask)
 
-            builder.ops.[builder.cursor] <- encodedValue
+            builder.ops[builder.cursor] <- encodedValue
             builder.cursor <- builder.cursor + 1
 
 
@@ -655,6 +655,6 @@ module StackAllocatedCollections =
             let res = Array.zeroCreate<'t> len
 
             for i = 0 to len - 1 do
-                res.[i] <- map(decode builder.ops.[i])
+                res[i] <- map(decode builder.ops[i])
 
             res

--- a/src/Fabulous/AttributeDefinitions.fs
+++ b/src/Fabulous/AttributeDefinitions.fs
@@ -191,15 +191,15 @@ module AttributeDefinitionStore =
 
     let getScalar (key: ScalarAttributeKey) : ScalarAttributeData =
         let index = ScalarAttributeKey.getKeyValue key
-        _scalars.[index]
+        _scalars[index]
 
     let getSmallScalar (key: ScalarAttributeKey) : SmallScalarAttributeData =
         let index = ScalarAttributeKey.getKeyValue key
-        _smallScalars.[index]
+        _smallScalars[index]
 
-    let getWidget (key: WidgetAttributeKey) : WidgetAttributeData = _widgets.[int key]
+    let getWidget (key: WidgetAttributeKey) : WidgetAttributeData = _widgets[int key]
 
-    let getWidgetCollection (key: WidgetCollectionAttributeKey) : WidgetCollectionAttributeData = _widgetCollections.[int key]
+    let getWidgetCollection (key: WidgetCollectionAttributeKey) : WidgetCollectionAttributeData = _widgetCollections[int key]
 
 module AttributeHelpers =
     open ScalarAttributeDefinitions

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -1,4 +1,4 @@
-﻿namespace Fabulous
+namespace Fabulous
 
 open System
 open System.Runtime.CompilerServices
@@ -213,7 +213,7 @@ module Attributes =
             for diff in diffs do
                 match diff with
                 | WidgetCollectionItemChange.Remove(index, widget) ->
-                    let itemNode = node.TreeContext.GetViewNode(box targetColl.[index])
+                    let itemNode = node.TreeContext.GetViewNode(box targetColl[index])
 
                     // Trigger the unmounted event
                     Dispatcher.dispatchEventForAllChildren itemNode widget Lifecycle.Unmounted
@@ -236,12 +236,12 @@ module Attributes =
                     Dispatcher.dispatchEventForAllChildren itemNode widget Lifecycle.Mounted
 
                 | WidgetCollectionItemChange.Update(index, widgetDiff) ->
-                    let childNode = node.TreeContext.GetViewNode(box targetColl.[index])
+                    let childNode = node.TreeContext.GetViewNode(box targetColl[index])
 
                     childNode.ApplyDiff(&widgetDiff)
 
                 | WidgetCollectionItemChange.Replace(index, oldWidget, newWidget) ->
-                    let prevItemNode = node.TreeContext.GetViewNode(box targetColl.[index])
+                    let prevItemNode = node.TreeContext.GetViewNode(box targetColl[index])
 
                     let struct (nextItemNode, view) = Helpers.createViewForWidget node newWidget
 
@@ -250,7 +250,7 @@ module Attributes =
                     prevItemNode.Disconnect()
 
                     // Replace the existing child in the UI tree at the index with the new one
-                    targetColl.[index] <- unbox view
+                    targetColl[index] <- unbox view
 
                     // Trigger the mounted event for the new child
                     Dispatcher.dispatchEventForAllChildren nextItemNode newWidget Lifecycle.Mounted

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -92,7 +92,7 @@ type WidgetBuilder<'msg, 'marker> =
                 | ValueSome attribs ->
                     let attribs2 = Array.zeroCreate(attribs.Length + 1)
                     Array.blit attribs 0 attribs2 0 attribs.Length
-                    attribs2.[attribs.Length] <- attr
+                    attribs2[attribs.Length] <- attr
                     attribs2
 
             WidgetBuilder<'msg, 'marker>(x.Key, struct (scalarAttributes, ValueSome res, widgetCollectionAttributes))
@@ -110,7 +110,7 @@ type WidgetBuilder<'msg, 'marker> =
                 | ValueSome attribs ->
                     let attribs2 = Array.zeroCreate(attribs.Length + 1)
                     Array.blit attribs 0 attribs2 0 attribs.Length
-                    attribs2.[attribs.Length] <- attr
+                    attribs2[attribs.Length] <- attr
                     attribs2
 
             WidgetBuilder<'msg, 'marker>(x.Key, struct (scalarAttributes, widgetAttributes, ValueSome res))

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -55,7 +55,7 @@ module Memo =
 
     let inline private getMemoData (widget: Widget) : MemoData =
         match widget.ScalarAttributes with
-        | ValueSome attrs when attrs.Length = 1 -> attrs.[0].Value :?> MemoData
+        | ValueSome attrs when attrs.Length = 1 -> attrs[0].Value :?> MemoData
         | _ -> failwith "Memo widget cannot have extra attributes"
 
     let internal canReuseMemoizedWidget prev next =

--- a/src/Fabulous/State.fs
+++ b/src/Fabulous/State.fs
@@ -11,13 +11,13 @@ module StateStore =
 
     let StateChanged = _stateChangedEvent.Publish
 
-    let get key = _states.[key]
+    let get key = _states[key]
 
     let set key newState =
         match _states.TryGetValue(key) with
         | true, prevState when prevState = newState -> ()
         | _ ->
-            _states.[key] <- newState
+            _states[key] <- newState
             _stateChangedEvent.Trigger({ Key = key; NewState = newState })
 
     let remove key = _states.Remove(key) |> ignore

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -119,7 +119,7 @@ type ViewNode(parent: IViewNode option, treeContext: ViewTreeContext, targetRef:
         member _.SetHandler<'T>(key: string, handlerOpt: 'T voption) =
             match handlerOpt with
             | ValueNone -> _handlers.Remove(key) |> ignore
-            | ValueSome v -> _handlers.[key] <- box v
+            | ValueSome v -> _handlers[key] <- box v
 
         member _.Disconnect() = _isDisconnected <- true
 

--- a/src/Fabulous/WidgetDefinitions.fs
+++ b/src/Fabulous/WidgetDefinitions.fs
@@ -17,8 +17,8 @@ module WidgetDefinitionStore =
 
     let mutable private _nextKey = 0
 
-    let get key = _widgets.[key]
-    let set key value = _widgets.[key] <- value
+    let get key = _widgets[key]
+    let set key value = _widgets[key] <- value
 
     let getNextKey () : WidgetKey =
         _widgets.Add(Unchecked.defaultof<WidgetDefinition>)

--- a/src/Fabulous/WidgetDiff.fs
+++ b/src/Fabulous/WidgetDiff.fs
@@ -50,10 +50,10 @@ module private SkipRepeatingScalars =
             pos
         else
             // that means that there is at least one more element ahead
-            let key = scalars.[pos].Key
+            let key = scalars[pos].Key
             let mutable resultingIndex = pos
 
-            while (length - 1 > resultingIndex) && (scalars.[resultingIndex + 1].Key = key) do
+            while (length - 1 > resultingIndex) && (scalars[resultingIndex + 1].Key = key) do
                 resultingIndex <- resultingIndex + 1
 
             resultingIndex
@@ -172,7 +172,7 @@ and [<Struct; IsByRefLike>] ScalarChangesEnumerator
             let i = e.prevIndex
 
             if i < attributes.Length then
-                let attribute = attributes.[i]
+                let attribute = attributes[i]
 
                 e.current <-
                     match added with
@@ -199,20 +199,20 @@ and [<Struct; IsByRefLike>] ScalarChangesEnumerator
                 if not(prevIndex >= prevLength && nextIndex >= nextLength) then
                     if prevIndex = prevLength then
                         // that means we are done with the prev and only need to add next's tail to added
-                        e.current <- ScalarChange.Added next.[nextIndex]
+                        e.current <- ScalarChange.Added next[nextIndex]
                         res <- ValueSome true
                         nextIndex <- nextIndex + 1
 
                     elif nextIndex = nextLength then
                         // that means that we are done with new items and only need prev's tail to removed
-                        e.current <- ScalarChange.Removed prev.[prevIndex]
+                        e.current <- ScalarChange.Removed prev[prevIndex]
                         res <- ValueSome true
                         prevIndex <- prevIndex + 1
 
                     else
                         // we haven't reached either of the ends
-                        let prevAttr = prev.[prevIndex]
-                        let nextAttr = next.[nextIndex]
+                        let prevAttr = prev[prevIndex]
+                        let nextAttr = next[nextIndex]
 
                         let prevKey = prevAttr.Key
                         let nextKey = nextAttr.Key
@@ -220,13 +220,13 @@ and [<Struct; IsByRefLike>] ScalarChangesEnumerator
                         match ScalarAttributeKey.compare prevKey nextKey with
                         | c when c < 0 ->
                             // prev key is less than next -> remove prev key
-                            e.current <- ScalarChange.Removed prev.[prevIndex]
+                            e.current <- ScalarChange.Removed prev[prevIndex]
                             res <- ValueSome true
                             prevIndex <- prevIndex + 1
 
                         | c when c > 0 ->
                             // prev key is more than next -> add next item
-                            e.current <- ScalarChange.Added next.[nextIndex]
+                            e.current <- ScalarChange.Added next[nextIndex]
                             res <- ValueSome true
                             nextIndex <- nextIndex + 1
 
@@ -235,7 +235,7 @@ and [<Struct; IsByRefLike>] ScalarChangesEnumerator
                             match ScalarAttributeKey.getKind prevKey with
                             | ScalarAttributeKey.Kind.Inline ->
                                 if prevAttr.NumericValue <> nextAttr.NumericValue then
-                                    e.current <- ScalarChange.Updated(prev.[prevIndex], next.[nextIndex])
+                                    e.current <- ScalarChange.Updated(prev[prevIndex], next[nextIndex])
                                     res <- ValueSome true
 
                             | ScalarAttributeKey.Kind.Boxed ->
@@ -245,7 +245,7 @@ and [<Struct; IsByRefLike>] ScalarChangesEnumerator
 
                                 // New value completely replaces the old value
                                 | ScalarAttributeComparison.Different ->
-                                    e.current <- ScalarChange.Updated(prev.[prevIndex], next.[nextIndex])
+                                    e.current <- ScalarChange.Updated(prev[prevIndex], next[nextIndex])
                                     res <- ValueSome true
 
                             // move both pointers
@@ -288,7 +288,7 @@ and [<Struct; IsByRefLike>] WidgetChangesEnumerator
             let i = e.prevIndex
 
             if i < values.Length then
-                let value = values.[i]
+                let value = values[i]
 
                 e.current <-
                     match added with
@@ -314,20 +314,20 @@ and [<Struct; IsByRefLike>] WidgetChangesEnumerator
                 if not(prevIndex >= prevLength && nextIndex >= nextLength) then
                     if prevIndex = prevLength then
                         // that means we are done with the prev and only need to add next's tail to added
-                        e.current <- WidgetChange.Added next.[nextIndex]
+                        e.current <- WidgetChange.Added next[nextIndex]
                         res <- ValueSome true
                         nextIndex <- nextIndex + 1
 
                     elif nextIndex = nextLength then
                         // that means that we are done with new items and only need prev's tail to removed
-                        e.current <- WidgetChange.Removed prev.[prevIndex]
+                        e.current <- WidgetChange.Removed prev[prevIndex]
                         res <- ValueSome true
                         prevIndex <- prevIndex + 1
 
                     else
                         // we haven't reached either of the ends
-                        let prevAttr = prev.[prevIndex]
-                        let nextAttr = next.[nextIndex]
+                        let prevAttr = prev[prevIndex]
+                        let nextAttr = next[nextIndex]
 
                         let prevKey = prevAttr.Key
                         let nextKey = nextAttr.Key
@@ -405,7 +405,7 @@ and [<Struct; IsByRefLike>] WidgetCollectionChangesEnumerator
             let i = e.prevIndex
 
             if i < values.Length then
-                let value = values.[i]
+                let value = values[i]
 
                 e.current <-
                     match added with
@@ -430,17 +430,17 @@ and [<Struct; IsByRefLike>] WidgetCollectionChangesEnumerator
                 if not(prevIndex >= prevLength && nextIndex >= nextLength) then
                     if prevIndex = prevLength then
                         // that means we are done with the prev and only need to add next's tail to added
-                        e.current <- WidgetCollectionChange.Added next.[nextIndex]
+                        e.current <- WidgetCollectionChange.Added next[nextIndex]
                         nextIndex <- nextIndex + 1
 
                     elif nextIndex = nextLength then
                         // that means that we are done with new items and only need prev's tail to removed
-                        e.current <- WidgetCollectionChange.Removed prev.[prevIndex]
+                        e.current <- WidgetCollectionChange.Removed prev[prevIndex]
                         prevIndex <- prevIndex + 1
                     else
                         // we haven't reached either of the ends
-                        let prevAttr = prev.[prevIndex]
-                        let nextAttr = next.[nextIndex]
+                        let prevAttr = prev[prevIndex]
+                        let nextAttr = next[nextIndex]
 
                         let prevKey = prevAttr.Key
                         let nextKey = nextAttr.Key
@@ -504,15 +504,15 @@ and [<Struct; IsByRefLike>] WidgetCollectionItemChangesEnumerator
         if prev.Length > next.Length && tailIndex < prev.Length - next.Length then
 
             let index = prev.Length - tailIndex - 1
-            e.current <- WidgetCollectionItemChange.Remove(index, prev.[index])
+            e.current <- WidgetCollectionItemChange.Remove(index, prev[index])
             e.tailIndex <- tailIndex + 1
 
             true
 
         elif i < next.Length then
-            let currItem = next.[i]
+            let currItem = next[i]
 
-            let prevItemOpt = if (i >= prev.Length) then ValueNone else ValueSome prev.[i]
+            let prevItemOpt = if (i >= prev.Length) then ValueNone else ValueSome prev[i]
 
             match prevItemOpt with
             | ValueNone -> e.current <- WidgetCollectionItemChange.Insert(i, currItem)


### PR DESCRIPTION
Use the (quite old now) F# 6.0 feature removing the need for a dot for accessing indexed properties