### PR TITLE
Add Cmd.debounce

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "5.2.0",
+      "version": "6.2.3",
       "commands": [
         "fantomas"
       ]

--- a/src/Fabulous.Tests/CmdTests.fs
+++ b/src/Fabulous.Tests/CmdTests.fs
@@ -31,4 +31,13 @@ type ``Cmd tests``() =
             do! Async.Sleep 125
 
             Assert.AreEqual(Some(NewValue 3), actualValue)
+
+            actualValue <- None
+
+            triggerCmd 4 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 75
+            triggerCmd 5 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 125
+
+            Assert.AreEqual(Some(NewValue 5), actualValue)
         }

--- a/src/Fabulous.Tests/CmdTests.fs
+++ b/src/Fabulous.Tests/CmdTests.fs
@@ -9,25 +9,26 @@ module CmdTestsHelper =
     let execute dispatch (cmd: Cmd<'msg>) =
         for sub in cmd do
             sub dispatch
-    
+
 [<TestFixture>]
 type ``Cmd tests``() =
     [<Test>]
     member _.``Cmd.debounce only dispatch the last message``() =
         async {
             let mutable actualValue = None
+
             let dispatch msg =
                 if actualValue.IsNone then
                     actualValue <- Some msg
-            
+
             let triggerCmd = Cmd.debounce 100 NewValue
-            
+
             triggerCmd 1 |> CmdTestsHelper.execute dispatch
             do! Async.Sleep 50
             triggerCmd 2 |> CmdTestsHelper.execute dispatch
             do! Async.Sleep 75
             triggerCmd 3 |> CmdTestsHelper.execute dispatch
             do! Async.Sleep 125
-            
+
             Assert.AreEqual(Some(NewValue 3), actualValue)
         }

--- a/src/Fabulous.Tests/CmdTests.fs
+++ b/src/Fabulous.Tests/CmdTests.fs
@@ -1,0 +1,33 @@
+namespace Fabulous.Tests
+
+open Fabulous
+open NUnit.Framework
+
+type CmdTestsMsg = NewValue of int
+
+module CmdTestsHelper =
+    let execute dispatch (cmd: Cmd<'msg>) =
+        for sub in cmd do
+            sub dispatch
+    
+[<TestFixture>]
+type ``Cmd tests``() =
+    [<Test>]
+    member _.``Cmd.debounce only dispatch the last message``() =
+        async {
+            let mutable actualValue = None
+            let dispatch msg =
+                if actualValue.IsNone then
+                    actualValue <- Some msg
+            
+            let triggerCmd = Cmd.debounce 100 NewValue
+            
+            triggerCmd 1 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 50
+            triggerCmd 2 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 75
+            triggerCmd 3 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 125
+            
+            Assert.AreEqual(Some(NewValue 3), actualValue)
+        }

--- a/src/Fabulous.Tests/Fabulous.Tests.fsproj
+++ b/src/Fabulous.Tests/Fabulous.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="AttributesTests.fs" />
     <Compile Include="ViewTests.fs" />
     <Compile Include="ArrayTests.fs" />
+    <Compile Include="CmdTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -38,9 +38,9 @@ type WidgetBuilder<'msg, 'marker> =
               DebugName = $"{typeof<'marker>.Name}<{typeof<'msg>.Name}>"
 #endif
               ScalarAttributes =
-                  match StackList.length &scalarAttributes with
-                  | 0us -> ValueNone
-                  | _ -> ValueSome(Array.sortInPlace (fun a -> a.Key) (StackList.toArray &scalarAttributes))
+                match StackList.length &scalarAttributes with
+                | 0us -> ValueNone
+                | _ -> ValueSome(Array.sortInPlace (fun a -> a.Key) (StackList.toArray &scalarAttributes))
 
               WidgetAttributes = ValueOption.map (Array.sortInPlace(fun a -> a.Key)) widgetAttributes
 

--- a/src/Fabulous/Cmd.fs
+++ b/src/Fabulous/Cmd.fs
@@ -122,6 +122,9 @@ module Cmd =
                       async {
                           do! Async.Sleep(timeout)
                           dispatch(fn value)
+
+                          cts.Dispose()
+                          cts <- null
                       },
                       cts.Token
                   ) ]

--- a/src/Fabulous/Cmd.fs
+++ b/src/Fabulous/Cmd.fs
@@ -105,24 +105,23 @@ module Cmd =
                       dispatch(failure ex)
               }
               |> ignore ]
-    
+
     /// Command to issue a message if no other message has been issued within the specified timeout
-    let debounce (timeout: int) (fn: 'value -> 'msg): 'value -> Cmd<'msg> =
+    let debounce (timeout: int) (fn: 'value -> 'msg) : 'value -> Cmd<'msg> =
         let mutable cts: CancellationTokenSource = null
-        
+
         fun (value: 'value) ->
             [ fun dispatch ->
-                if cts <> null then
-                    cts.Cancel()
-                    cts.Dispose()
-                
-                cts <- new CancellationTokenSource()
-                
-                Async.Start(
-                    async {
-                        do! Async.Sleep(timeout)
-                        dispatch (fn value)
-                    },
-                    cts.Token
-                )
-            ]
+                  if cts <> null then
+                      cts.Cancel()
+                      cts.Dispose()
+
+                  cts <- new CancellationTokenSource()
+
+                  Async.Start(
+                      async {
+                          do! Async.Sleep(timeout)
+                          dispatch(fn value)
+                      },
+                      cts.Token
+                  ) ]

--- a/src/Fabulous/Cmd.fs
+++ b/src/Fabulous/Cmd.fs
@@ -1,5 +1,6 @@
 ﻿namespace Fabulous
 
+open System.Threading
 open System.Threading.Tasks
 
 /// Dispatch - feed new message into the processing loop
@@ -104,3 +105,24 @@ module Cmd =
                       dispatch(failure ex)
               }
               |> ignore ]
+    
+    /// Command to issue a message if no other message has been issued within the specified timeout
+    let debounce (timeout: int) (fn: 'value -> 'msg): 'value -> Cmd<'msg> =
+        let mutable cts: CancellationTokenSource = null
+        
+        fun (value: 'value) ->
+            [ fun dispatch ->
+                if cts <> null then
+                    cts.Cancel()
+                    cts.Dispose()
+                
+                cts <- new CancellationTokenSource()
+                
+                Async.Start(
+                    async {
+                        do! Async.Sleep(timeout)
+                        dispatch (fn value)
+                    },
+                    cts.Token
+                )
+            ]


### PR DESCRIPTION
Following https://github.com/fabulous-dev/Fabulous/discussions/1061, add a `Cmd.debounce` helper to debounce events like Entry.TextChanged, etc.

Usage:
```fs
type Model =
    { EntryValue: string
      ValidatedText: string }

type Msg =
    | TextChanged of string
    | TextValidated of string

let validateTextCmd =
    Cmd.debounce 300 (fun value ->
       TextValidated value
    )

let update msg model =
    match msg with
    | TextChanged newValue -> { model with EntryValue = newValue }, validateTextCmd newValue
    | TextValidated value -> { model with ValidatedText = value }, Cmd.none

let view model =
    VStack() {
        Entry(model.EntryValue, TextChanged)
        Label($"Validated text: {model.ValidatedText}")
    }
```