### PR TITLE
Dispose properly ViewNode and Component when Widget is removed from tree

### DIFF
--- a/src/Fabulous.Tests/APISketchTests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Attributes.fs
@@ -18,18 +18,22 @@ module TestUI_Attributes =
 
                         let btn = node.Target :?> IButton
 
-                        match node.TryGetHandler<int>(name) with
+                        match node.TryGetHandler(name) with
                         | ValueNone -> ()
-                        | ValueSome handlerId -> btn.RemovePressListener handlerId
+                        | ValueSome handler -> handler.Dispose()
 
                         match newValueOpt with
-                        | ValueNone -> node.SetHandler(name, ValueNone)
+                        | ValueNone -> node.RemoveHandler(name)
 
                         | ValueSome msg ->
                             let handler () = Dispatcher.dispatch node msg
-
                             let handlerId = btn.AddPressListener handler
-                            node.SetHandler<int>(name, ValueSome handlerId))
+
+                            let disposable =
+                                { new IDisposable with
+                                    member _.Dispose() = btn.RemovePressListener handlerId }
+
+                            node.SetHandler(name, disposable))
                 )
                 |> AttributeDefinitionStore.registerScalar
 
@@ -44,18 +48,22 @@ module TestUI_Attributes =
 
                         let btn = node.Target :?> IButton
 
-                        match node.TryGetHandler<int>(name) with
+                        match node.TryGetHandler(name) with
                         | ValueNone -> ()
-                        | ValueSome handlerId -> btn.RemoveTapListener handlerId
+                        | ValueSome handler -> handler.Dispose()
 
                         match newValueOpt with
-                        | ValueNone -> node.SetHandler(name, ValueNone)
+                        | ValueNone -> node.RemoveHandler(name)
 
                         | ValueSome msg ->
                             let handler () = Dispatcher.dispatch node msg
-
                             let handlerId = btn.AddTapListener handler
-                            node.SetHandler<int>(name, ValueSome handlerId))
+
+                            let disposable =
+                                { new IDisposable with
+                                    member _.Dispose() = btn.RemoveTapListener handlerId }
+
+                            node.SetHandler(name, disposable))
                 )
                 |> AttributeDefinitionStore.registerScalar
 
@@ -70,18 +78,22 @@ module TestUI_Attributes =
 
                         let btn = node.Target :?> IButton
 
-                        match node.TryGetHandler<int>(name) with
+                        match node.TryGetHandler(name) with
                         | ValueNone -> ()
-                        | ValueSome handlerId -> btn.RemoveTap2Listener handlerId
+                        | ValueSome handler -> handler.Dispose()
 
                         match newValueOpt with
-                        | ValueNone -> node.SetHandler(name, ValueNone)
+                        | ValueNone -> node.RemoveHandler(name)
 
                         | ValueSome msg ->
                             let handler () = Dispatcher.dispatch node msg
-
                             let handlerId = btn.AddTap2Listener handler
-                            node.SetHandler<int>(name, ValueSome handlerId))
+
+                            let disposable =
+                                { new IDisposable with
+                                    member _.Dispose() = btn.RemoveTap2Listener handlerId }
+
+                            node.SetHandler(name, disposable))
                 )
                 |> AttributeDefinitionStore.registerScalar
 
@@ -96,18 +108,22 @@ module TestUI_Attributes =
 
                         let btn = node.Target :?> IContainer
 
-                        match node.TryGetHandler<int>(name) with
+                        match node.TryGetHandler(name) with
                         | ValueNone -> ()
-                        | ValueSome handlerId -> btn.RemoveTapListener handlerId
+                        | ValueSome handler -> handler.Dispose()
 
                         match newValueOpt with
-                        | ValueNone -> node.SetHandler(name, ValueNone)
+                        | ValueNone -> node.RemoveHandler(name)
 
                         | ValueSome msg ->
                             let handler () = Dispatcher.dispatch node msg
-
                             let handlerId = btn.AddTapListener handler
-                            node.SetHandler<int>(name, ValueSome handlerId))
+
+                            let disposable =
+                                { new IDisposable with
+                                    member _.Dispose() = btn.RemoveTapListener handlerId }
+
+                            node.SetHandler(name, disposable))
                 )
                 |> AttributeDefinitionStore.registerScalar
 

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Component.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Component.fs
@@ -9,4 +9,9 @@ module TestUI_Component =
         let ComponentProperty = "ComponentProperty"
 
         let getComponent (target: obj) =
-            (target :?> TestViewElement).PropertyBag.Item ComponentProperty
+            match (target :?> TestViewElement).PropertyBag.TryGetValue(ComponentProperty) with
+            | true, comp -> comp
+            | _ -> null
+
+        let setComponent (comp: obj) (target: obj) =
+            (target :?> TestViewElement).PropertyBag.Add(ComponentProperty, comp)

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -41,7 +41,7 @@ module TestUI_Widgets =
                             | ValueNone -> None
                             | ValueSome parent -> Some parent
 
-                        let viewNode = ViewNode(parentNode, context, weakReference)
+                        let viewNode = new ViewNode(parentNode, context, weakReference)
 
                         view.PropertyBag.Add(ViewNode.ViewNodeProperty, viewNode)
 
@@ -214,6 +214,7 @@ module TestUI_Widgets =
                       MinLogLevel = LogLevel.Fatal }
                   Dispatch = fun msg -> unbox<'msg> msg |> x.ProcessMessage
                   GetComponent = Component.getComponent
+                  SetComponent = Component.setComponent
                   SyncAction = fun fn -> fn() }
 
             member x.ProcessMessage(msg: 'msg) =

--- a/src/Fabulous/Cmd.fs
+++ b/src/Fabulous/Cmd.fs
@@ -7,16 +7,30 @@ open System.Threading.Tasks
 type Dispatch<'msg> = 'msg -> unit
 
 /// Subscription - return immediately, but may schedule dispatch of a message at any time
-type Sub<'msg> = Dispatch<'msg> -> unit
+type Effect<'msg> = Dispatch<'msg> -> unit
 
-/// Cmd - container for subscriptions that may produce messages
-type Cmd<'msg> = Sub<'msg> list
+/// Cmd - container for effects that may produce messages
+type Cmd<'msg> = Effect<'msg> list
 
 /// Cmd module for creating and manipulating commands
 [<RequireQualifiedAccess>]
 module Cmd =
+    /// Execute the commands using the supplied dispatcher
+    let internal exec onError (dispatch: Dispatch<'msg>) (cmd: Cmd<'msg>) =
+        cmd |> List.iter (fun call -> try call dispatch with ex -> onError ex)
+    
     /// None - no commands, also known as `[]`
     let none: Cmd<'msg> = []
+
+    /// When emitting the message, map to another type
+    let map (f: 'a -> 'msg) (cmd: Cmd<'a>) : Cmd<'msg> =
+        cmd |> List.map(fun g -> (fun dispatch -> f >> dispatch) >> g)
+
+    /// Aggregate multiple commands
+    let batch (cmds: Cmd<'msg> list) : Cmd<'msg> = List.concat cmds
+
+    /// Command to call the effect
+    let ofEffect (effect: Effect<'msg>) : Cmd<'msg> = [ effect ]
 
     /// Command to issue a specific message
     let ofMsg (msg: 'msg) : Cmd<'msg> = [ fun dispatch -> dispatch msg ]
@@ -27,84 +41,171 @@ module Cmd =
               match msg with
               | None -> ()
               | Some msg -> dispatch msg ]
+        
+    module OfFunc =
+        /// Command to evaluate a simple function and map the result
+        /// into success or error (of exception)
+        let either (task: 'a -> _) (arg: 'a) (ofSuccess: _ -> 'msg) (ofError: _ -> 'msg) : Cmd<'msg> =
+            let bind dispatch =
+                try
+                    task arg
+                    |> (ofSuccess >> dispatch)
+                with x ->
+                    x |> (ofError >> dispatch)
+            [bind]
 
-    /// When emitting the message, map to another type
-    let map (f: 'a -> 'msg) (cmd: Cmd<'a>) : Cmd<'msg> =
-        cmd |> List.map(fun g -> (fun dispatch -> f >> dispatch) >> g)
+        /// Command to evaluate a simple function and map the success to a message
+        /// discarding any possible error
+        let perform (task: 'a -> _) (arg: 'a) (ofSuccess: _ -> 'msg) : Cmd<'msg> =
+            let bind dispatch =
+                try
+                    task arg
+                    |> (ofSuccess >> dispatch)
+                with x ->
+                    ()
+            [bind]
 
-    /// Aggregate multiple commands
-    let batch (cmds: #seq<Cmd<'msg>>) : Cmd<'msg> = cmds |> List.concat
+        /// Command to evaluate a simple function and map the error (in case of exception)
+        let attempt (task: 'a -> unit) (arg: 'a) (ofError: _ -> 'msg) : Cmd<'msg> =
+            let bind dispatch =
+                try
+                    task arg
+                with x ->
+                    x |> (ofError >> dispatch)
+            [bind]
 
-    /// Command to call the subscriber
-    let ofSub (sub: Sub<'msg>) : Cmd<'msg> = [ sub ]
+    module OfAsyncWith =
+        /// Command that will evaluate an async block and map the result
+        /// into success or error (of exception)
+        let either (start: Async<unit> -> unit)
+                   (task: 'a -> Async<_>)
+                   (arg: 'a)
+                   (ofSuccess: _ -> 'msg)
+                   (ofError: _ -> 'msg) : Cmd<'msg> =
+            let bind dispatch =
+                async {
+                    let! r = task arg |> Async.Catch
+                    dispatch (match r with
+                             | Choice1Of2 x -> ofSuccess x
+                             | Choice2Of2 x -> ofError x)
+                }
+            [bind >> start]
 
-    let dispatch d (cmd: Cmd<_>) =
-        for sub in cmd do
-            sub d
+        /// Command that will evaluate an async block and map the success
+        let perform (start: Async<unit> -> unit)
+                    (task: 'a -> Async<_>)
+                    (arg: 'a)
+                    (ofSuccess: _ -> 'msg) : Cmd<'msg> =
+            let bind dispatch =
+                async {
+                    let! r = task arg |> Async.Catch
+                    match r with
+                    | Choice1Of2 x -> dispatch (ofSuccess x)
+                    | _ -> ()
+                }
+            [bind >> start]
 
-    /// Command to issue a message at the end of an asynchronous task
-    let ofAsyncMsg (p: Async<'msg>) : Cmd<'msg> =
-        [ fun dispatch ->
-              async {
-                  let! msg = p
-                  dispatch msg
-              }
-              |> Async.StartImmediate ]
+        /// Command that will evaluate an async block and map the error (of exception)
+        let attempt (start: Async<unit> -> unit)
+                    (task: 'a -> Async<_>)
+                    (arg: 'a)
+                    (ofError: _ -> 'msg) : Cmd<'msg> =
+            let bind dispatch =
+                async {
+                    let! r = task arg |> Async.Catch
+                    match r with
+                    | Choice2Of2 x -> dispatch (ofError x)
+                    | _ -> ()
+                }
+            [bind >> start]
 
-    /// Command to issue a message at the end of an asynchronous task, only when Option.IsSome = true
-    let ofAsyncMsgOption (p: Async<'msg option>) : Cmd<'msg> =
-        [ fun dispatch ->
-              async {
-                  let! msg = p
+        /// Command that will evaluate an async block and map the success
+        let performOption (start: Async<unit> -> unit)
+                    (task: 'a -> Async<_ option>)
+                    (arg: 'a)
+                    (ofSuccess: _ -> 'msg) : Cmd<'msg> =
+            let bind dispatch =
+                async {
+                    let! r = task arg
+                    match r with
+                    | Some x -> dispatch (ofSuccess x)
+                    | None -> ()
+                }
+            [bind >> start]
 
-                  match msg with
-                  | None -> ()
-                  | Some msg -> dispatch msg
-              }
-              |> Async.StartImmediate ]
+    module OfAsync =
+        /// Command that will evaluate an async block and map the result
+        /// into success or error (of exception)
+        let inline either (task: 'a -> Async<_>)
+                          (arg: 'a)
+                          (ofSuccess: _ -> 'msg)
+                          (ofError: _ -> 'msg) : Cmd<'msg> =
+            OfAsyncWith.either Async.Start task arg ofSuccess ofError
 
-    /// Command to issue a message ot the end of an asynchronous task returning a Result
-    let ofAsyncResult (p: Async<Result<'data, 'exn>>) (success: 'data -> 'msg) (error: 'exn -> 'msg) (failure: exn -> 'msg) : Cmd<'msg> =
-        [ fun dispatch ->
-              async {
-                  try
-                      let! result = p
+        /// Command that will evaluate an async block and map the success
+        let inline perform (task: 'a -> Async<_>)
+                           (arg: 'a)
+                           (ofSuccess: _ -> 'msg) : Cmd<'msg> =
+            OfAsyncWith.perform Async.Start task arg ofSuccess
 
-                      match result with
-                      | Ok x -> dispatch(success x)
-                      | Error x -> dispatch(error x)
-                  with ex ->
-                      dispatch(failure ex)
-              }
-              |> Async.StartImmediate ]
+        /// Command that will evaluate an async block and map the error (of exception)
+        let inline attempt (task: 'a -> Async<_>)
+                           (arg: 'a)
+                           (ofError: _ -> 'msg) : Cmd<'msg> =
+            OfAsyncWith.attempt Async.Start task arg ofError
+            
+        let inline msg (task: Async<'msg>) =
+            OfAsyncWith.perform Async.Start (fun () -> task) () id
+            
+        let inline msgOption (task: Async<'msg option>) =
+            OfAsyncWith.performOption Async.Start (fun () -> task) () id
 
-    /// Command to issue a message at the end of an asynchronous task
-    let ofTaskMsg (p: Task<'msg>) : Cmd<'msg> =
-        [ fun dispatch ->
-              task {
-                  try
-                      let! result = p
-                      dispatch result
-                  with _ex ->
-                      // TODO: log exception
-                      ()
-              }
-              |> ignore ]
+    module OfAsyncImmediate =
+        /// Command that will evaluate an async block and map the result
+        /// into success or error (of exception)
+        let inline either (task: 'a -> Async<_>)
+                          (arg: 'a)
+                          (ofSuccess: _ -> 'msg)
+                          (ofError: _ -> 'msg) : Cmd<'msg> =
+            OfAsyncWith.either Async.StartImmediate task arg ofSuccess ofError
 
-    /// Command to issue a message at the end of an asynchronous task
-    let ofTaskResult (p: Task<Result<'data, 'exn>>) (success: 'data -> 'msg) (error: 'exn -> 'msg) (failure: exn -> 'msg) : Cmd<'msg> =
-        [ fun dispatch ->
-              task {
-                  try
-                      let! result = p
+        /// Command that will evaluate an async block and map the success
+        let inline perform (task: 'a -> Async<_>)
+                           (arg: 'a)
+                           (ofSuccess: _ -> 'msg) : Cmd<'msg> =
+            OfAsyncWith.perform Async.StartImmediate task arg ofSuccess
 
-                      match result with
-                      | Ok x -> dispatch(success x)
-                      | Error x -> dispatch(error x)
-                  with ex ->
-                      dispatch(failure ex)
-              }
-              |> ignore ]
+        /// Command that will evaluate an async block and map the error (of exception)
+        let inline attempt (task: 'a -> Async<_>)
+                           (arg: 'a)
+                           (ofError: _ -> 'msg) : Cmd<'msg> =
+            OfAsyncWith.attempt Async.StartImmediate task arg ofError
+
+    module OfTask =
+        /// Command to call a task and map the results
+        let inline either (task: 'a -> Task<_>)
+                          (arg:'a)
+                          (ofSuccess: _ -> 'msg)
+                          (ofError: _ -> 'msg) : Cmd<'msg> =
+            OfAsync.either (task >> Async.AwaitTask) arg ofSuccess ofError
+
+        /// Command to call a task and map the success
+        let inline perform (task: 'a -> Task<_>)
+                           (arg:'a)
+                           (ofSuccess: _ -> 'msg) : Cmd<'msg> =
+            OfAsync.perform (task >> Async.AwaitTask) arg ofSuccess
+
+        /// Command to call a task and map the error
+        let inline attempt (task: 'a -> #Task)
+                           (arg:'a)
+                           (ofError: _ -> 'msg) : Cmd<'msg> =
+            OfAsync.attempt (task >> Async.AwaitTask) arg ofError
+            
+        let inline msg (task: Task<'msg>) =
+            OfAsync.msg (task |> Async.AwaitTask)
+            
+        let inline msgOption (task: Task<'msg option>) =
+            OfAsync.msgOption (task |> Async.AwaitTask)
 
     /// Command to issue a message if no other message has been issued within the specified timeout
     let debounce (timeout: int) (fn: 'value -> 'msg) : 'value -> Cmd<'msg> =

--- a/src/Fabulous/Component.fs
+++ b/src/Fabulous/Component.fs
@@ -357,7 +357,7 @@ module Component =
                         let comp = new Component(treeContext, data.Body, ctx)
                         let struct (node, view) = comp.CreateView(ValueSome widget)
 
-                        treeContext.SetComponent view comp
+                        treeContext.SetComponent comp view
 
                         struct (node, view)
               AttachView =
@@ -374,7 +374,7 @@ module Component =
                         let comp = new Component(treeContext, data.Body, ctx)
                         let node = comp.AttachView(widget, view)
 
-                        treeContext.SetComponent view comp
+                        treeContext.SetComponent comp view
 
                         node }
 

--- a/src/Fabulous/Component.fs
+++ b/src/Fabulous/Component.fs
@@ -315,14 +315,14 @@ type Component(treeContext: ViewTreeContext, body: ComponentBody, context: Compo
         let viewNode = treeContext.GetViewNode _view
 
         Reconciler.update treeContext.CanReuseView (ValueSome prevRootWidget) currRootWidget viewNode
-        
+
     member this.Dispose() =
         if _contextSubscription <> null then
             _contextSubscription.Dispose()
-            
+
         if _context <> null then
             _context.Dispose()
-            
+
         _body <- null
         _widget <- Unchecked.defaultof<_>
         _view <- null

--- a/src/Fabulous/ComponentContext.fs
+++ b/src/Fabulous/ComponentContext.fs
@@ -1,5 +1,6 @@
 namespace Fabulous
 
+open System
 open System.ComponentModel
 
 (*
@@ -18,6 +19,7 @@ we can leverage the inlining capabilities of the ComponentBuilder to create an a
 /// <summary>
 /// Holds the values for the various states of a component.
 /// </summary>
+[<AllowNullLiteral>]
 type ComponentContext(initialSize: int) =
     static let mutable nextId = 0
 
@@ -27,11 +29,12 @@ type ComponentContext(initialSize: int) =
 
     let id = getNextId()
     let mutable values = Array.zeroCreate initialSize
+    let disposables = System.Collections.Generic.List<IDisposable>()
 
     let renderNeeded = Event<unit>()
 
     // We assume that most components will have few values, so initialize it with a small array
-    new() = ComponentContext(3)
+    new() = new ComponentContext(3)
 
     member this.Id = id
 
@@ -64,6 +67,19 @@ type ComponentContext(initialSize: int) =
     member this.SetValue(key: int, value: 'T) =
         this.SetValueInternal(key, value)
         this.NeedsRender()
+        
+    member this.LinkDisposable(disposable: IDisposable) =
+        disposables.Add(disposable)
+        
+    member this.Dispose() =
+        for disposable in disposables do
+            disposable.Dispose()
+        disposables.Clear()
+        
+        values <- Array.empty
+        
+    interface IDisposable with
+        member this.Dispose() = this.Dispose()
 
 [<AbstractClass; Sealed>]
 type Context private () =

--- a/src/Fabulous/ComponentContext.fs
+++ b/src/Fabulous/ComponentContext.fs
@@ -67,17 +67,17 @@ type ComponentContext(initialSize: int) =
     member this.SetValue(key: int, value: 'T) =
         this.SetValueInternal(key, value)
         this.NeedsRender()
-        
-    member this.LinkDisposable(disposable: IDisposable) =
-        disposables.Add(disposable)
-        
+
+    member this.LinkDisposable(disposable: IDisposable) = disposables.Add(disposable)
+
     member this.Dispose() =
         for disposable in disposables do
             disposable.Dispose()
+
         disposables.Clear()
-        
+
         values <- Array.empty
-        
+
     interface IDisposable with
         member this.Dispose() = this.Dispose()
 

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -33,6 +33,7 @@
     <Compile Include="Reconciler.fs" />
     <Compile Include="ViewNode.fs" />
     <Compile Include="Cmd.fs" />
+    <Compile Include="Sub.fs" />
     <Compile Include="Program.fs" />
     <Compile Include="Runner.fs" />
     <Compile Include="MapMsg.fs" />

--- a/src/Fabulous/IViewNode.fs
+++ b/src/Fabulous/IViewNode.fs
@@ -36,7 +36,8 @@ type ViewTreeContext =
       Logger: Logger
       Dispatch: obj -> unit
       SyncAction: (unit -> unit) -> unit
-      GetComponent: obj -> obj }
+      GetComponent: obj -> obj
+      SetComponent: obj -> obj -> unit }
 
 and IViewNode =
     /// The view that is being rendered

--- a/src/Fabulous/IViewNode.fs
+++ b/src/Fabulous/IViewNode.fs
@@ -1,5 +1,6 @@
 namespace Fabulous
 
+open System
 open Fabulous
 
 type ViewRef(onAttached, onDetached) =
@@ -40,6 +41,8 @@ type ViewTreeContext =
       SetComponent: obj -> obj -> unit }
 
 and IViewNode =
+    inherit IDisposable
+
     /// The view that is being rendered
     abstract member Target: obj
 
@@ -62,13 +65,12 @@ and IViewNode =
     abstract member MapMsg: (obj -> obj) option with get, set
 
     /// Return the event handler for a given attribute key if set
-    abstract member TryGetHandler<'T> : string -> 'T voption
+    abstract member TryGetHandler: string -> IDisposable voption
 
     /// Set the event handler for a given attribute name
-    abstract member SetHandler<'T> : string * 'T voption -> unit
+    abstract member SetHandler: string * IDisposable -> unit
 
-    /// Disconnect the node from the tree
-    abstract member Disconnect: unit -> unit
+    abstract member RemoveHandler: string -> unit
 
     /// Apply the diffing result to this node
     abstract member ApplyDiff: WidgetDiff inref -> unit

--- a/src/Fabulous/MvuComponent.fs
+++ b/src/Fabulous/MvuComponent.fs
@@ -28,7 +28,9 @@ module MvuComponent =
 
                         let ctx = new ComponentContext(1)
 
-                        let runner = new Runner<obj, obj, obj>((fun () -> ctx.TryGetValue(0).Value), (fun v -> ctx.SetValue(0, v)), data.Program)
+                        let runner =
+                            new Runner<obj, obj, obj>((fun () -> ctx.TryGetValue(0).Value), (fun v -> ctx.SetValue(0, v)), data.Program)
+
                         ctx.LinkDisposable(runner)
 
                         runner.Start(data.Arg)
@@ -38,7 +40,7 @@ module MvuComponent =
                             { treeContext with
                                 Dispatch = runner.Dispatch }
 
-                        let comp = new Component(treeContext, data.Body, ctx)                        
+                        let comp = new Component(treeContext, data.Body, ctx)
                         let struct (node, view) = comp.CreateView(ValueSome widget)
 
                         treeContext.SetComponent view comp
@@ -56,7 +58,9 @@ module MvuComponent =
 
                         let ctx = new ComponentContext(1)
 
-                        let runner = new Runner<obj, obj, obj>((fun () -> ctx.TryGetValue(0).Value), (fun v -> ctx.SetValue(0, v)), data.Program)
+                        let runner =
+                            new Runner<obj, obj, obj>((fun () -> ctx.TryGetValue(0).Value), (fun v -> ctx.SetValue(0, v)), data.Program)
+
                         ctx.LinkDisposable(runner)
 
                         runner.Start(data.Arg)

--- a/src/Fabulous/MvuComponent.fs
+++ b/src/Fabulous/MvuComponent.fs
@@ -43,7 +43,7 @@ module MvuComponent =
                         let comp = new Component(treeContext, data.Body, ctx)
                         let struct (node, view) = comp.CreateView(ValueSome widget)
 
-                        treeContext.SetComponent view comp
+                        treeContext.SetComponent comp view
 
                         struct (node, view)
               AttachView =
@@ -73,7 +73,7 @@ module MvuComponent =
                         let comp = new Component(treeContext, data.Body, ctx)
                         let node = comp.AttachView(widget, view)
 
-                        treeContext.SetComponent view comp
+                        treeContext.SetComponent comp view
 
                         node }
 

--- a/src/Fabulous/Program.fs
+++ b/src/Fabulous/Program.fs
@@ -73,12 +73,12 @@ module Program =
     /// Subscribe to external source of events, overrides existing subscription.
     /// Return the subscriptions that should be active based on the current model.
     /// Subscriptions will be started or stopped automatically to match.
-    let withSubscription (subscribe: 'model -> Sub<'msg>) (program: Program<'arg, 'model, 'msg>) =
-        { program with Subscribe = subscribe }
-        
+    let withSubscription (subscribe: 'model -> Sub<'msg>) (program: Program<'arg, 'model, 'msg>) = { program with Subscribe = subscribe }
+
     /// Map existing subscription to external source of events.
     let mapSubscription map (program: Program<'arg, 'model, 'msg>) =
-        { program with Subscribe = map program.Subscribe }
+        { program with
+            Subscribe = map program.Subscribe }
 
     /// Configure how the output messages from Fabulous will be handled
     let withLogger (logger: Logger) (program: Program<'arg, 'model, 'msg>) = { program with Logger = logger }

--- a/src/Fabulous/Program.fs
+++ b/src/Fabulous/Program.fs
@@ -11,7 +11,7 @@ type Program<'arg, 'model, 'msg> =
         /// Update the application state based on a message
         Update: 'msg * 'model -> 'model * Cmd<'msg>
         /// Add a subscription that can dispatch messages
-        Subscribe: 'model -> Cmd<'msg>
+        Subscribe: 'model -> Sub<'msg>
         /// Configuration for logging all output messages from Fabulous
         Logger: Logger
         /// Exception handler for all uncaught exceptions happening in the MVU loop.
@@ -54,7 +54,7 @@ module Program =
     let inline private define (init: 'arg -> 'model * Cmd<'msg>) (update: 'msg -> 'model -> 'model * Cmd<'msg>) =
         { Init = init
           Update = (fun (msg, model) -> update msg model)
-          Subscribe = fun _ -> Cmd.none
+          Subscribe = fun _ -> Sub.none
           Logger = ProgramDefaults.defaultLogger()
           ExceptionHandler = ProgramDefaults.defaultExceptionHandler }
 
@@ -70,13 +70,15 @@ module Program =
         let mapCmds cmdMsgs = cmdMsgs |> List.map mapCmd |> Cmd.batch
         define (fun arg -> let m, c = init arg in m, mapCmds c) (fun msg model -> let m, c = update msg model in m, mapCmds c)
 
-    /// Subscribe to external source of events.
-    /// The subscription is called once - with the initial model, but can dispatch new messages at any time.
-    let withSubscription (subscribe: 'model -> Cmd<'msg>) (program: Program<'arg, 'model, 'msg>) =
-        let sub model =
-            Cmd.batch [ program.Subscribe model; subscribe model ]
-
-        { program with Subscribe = sub }
+    /// Subscribe to external source of events, overrides existing subscription.
+    /// Return the subscriptions that should be active based on the current model.
+    /// Subscriptions will be started or stopped automatically to match.
+    let withSubscription (subscribe: 'model -> Sub<'msg>) (program: Program<'arg, 'model, 'msg>) =
+        { program with Subscribe = subscribe }
+        
+    /// Map existing subscription to external source of events.
+    let mapSubscription map (program: Program<'arg, 'model, 'msg>) =
+        { program with Subscribe = map program.Subscribe }
 
     /// Configure how the output messages from Fabulous will be handled
     let withLogger (logger: Logger) (program: Program<'arg, 'model, 'msg>) = { program with Logger = logger }

--- a/src/Fabulous/Runner.fs
+++ b/src/Fabulous/Runner.fs
@@ -76,6 +76,7 @@ type Runner<'arg, 'model, 'msg>(getState: unit -> 'model, setState: 'model -> un
         try
             _reentering <- true
             Sub.Internal.Fx.stop onError _activeSubs
+            _activeSubs <- Sub.Internal.empty
         with ex ->
             _reentering <- false
 

--- a/src/Fabulous/Runner.fs
+++ b/src/Fabulous/Runner.fs
@@ -1,5 +1,6 @@
 namespace Fabulous
 
+open System
 open System.Collections.Concurrent
 
 // Runners are responsible for the Model-Update part of MVU.
@@ -7,8 +8,35 @@ open System.Collections.Concurrent
 
 /// Create a new Runner handling the update loop for the component
 type Runner<'arg, 'model, 'msg>(getState: unit -> 'model, setState: 'model -> unit, program: Program<'arg, 'model, 'msg>) =
+    let mutable _activeSubs = Sub.Internal.empty
     let mutable _reentering = false
     let queue = ConcurrentQueue<'msg>()
+                
+    let onError (message, exn) =
+        let ex = Exception(message, exn)
+        if not(program.ExceptionHandler ex) then
+            raise ex
+            
+    let processMsgs dispatch msg =
+        let mutable lastMsg = ValueSome msg
+        
+        while lastMsg.IsSome do
+            let model = getState()
+            let newModel, cmd = program.Update(lastMsg.Value, model)
+            let subs = program.Subscribe(newModel)
+            
+            setState newModel
+            
+            _activeSubs <-
+                Sub.Internal.diff _activeSubs subs
+                |> Sub.Internal.Fx.change onError dispatch
+                
+            Cmd.exec (fun ex -> onError("Error updating", ex)) dispatch cmd
+
+            lastMsg <-
+                match queue.TryDequeue() with
+                | false, _ -> ValueNone
+                | true, msg -> ValueSome msg
 
     let rec dispatch msg =
         try
@@ -16,42 +44,41 @@ type Runner<'arg, 'model, 'msg>(getState: unit -> 'model, setState: 'model -> un
                 queue.Enqueue(msg)
             else
                 _reentering <- true
-
-                let mutable lastMsg = ValueSome msg
-
-                while lastMsg.IsSome do
-                    let model = getState()
-                    let newModel, cmd = program.Update(lastMsg.Value, model)
-                    setState newModel
-
-                    for sub in cmd do
-                        sub dispatch
-
-                    lastMsg <-
-                        match queue.TryDequeue() with
-                        | false, _ -> ValueNone
-                        | true, msg -> ValueSome msg
-
+                processMsgs dispatch msg
                 _reentering <- false
         with ex ->
             _reentering <- false
-
             if not(program.ExceptionHandler ex) then
                 reraise()
 
     let start arg =
         try
+            _reentering <- true
+            
             let model, cmd = program.Init(arg)
             setState model
 
+            // Start the subscriptions
             let subs = program.Subscribe(model)
+            _activeSubs <-
+                Sub.Internal.diff _activeSubs subs
+                |> Sub.Internal.Fx.change onError dispatch
 
-            for sub in subs do
-                sub dispatch
-
-            for sub in cmd do
-                sub dispatch
+            // Execute the commands
+            Cmd.exec (fun ex -> onError("Error initializing", ex)) dispatch cmd
+                
+            _reentering <- false
         with ex ->
+            _reentering <- false
+            if not(program.ExceptionHandler(ex)) then
+                reraise()
+                
+    let stop () =
+        try
+            _reentering <- true
+            Sub.Internal.Fx.stop onError _activeSubs
+        with ex ->
+            _reentering <- false
             if not(program.ExceptionHandler(ex)) then
                 reraise()
 
@@ -60,3 +87,6 @@ type Runner<'arg, 'model, 'msg>(getState: unit -> 'model, setState: 'model -> un
 
     /// Dispatch a message to the Runner loop
     member _.Dispatch(msg) = dispatch msg
+
+    interface IDisposable with
+        member _.Dispose() = stop ()

--- a/src/Fabulous/Sub.fs
+++ b/src/Fabulous/Sub.fs
@@ -1,0 +1,90 @@
+namespace Fabulous
+
+open System
+
+/// SubId - Subscription ID, alias for string list
+type SubId = string list
+
+/// Subscribe - Starts a subscription, returns IDisposable to stop it
+type Subscribe<'msg> = Dispatch<'msg> -> IDisposable
+
+/// Subscription - Generates new messages when running
+type Sub<'msg> = (SubId * Subscribe<'msg>) list
+
+module Sub =
+
+    /// None - no subscriptions, also known as `[]`
+    let none : Sub<'msg> =
+        []
+
+    /// Aggregate multiple subscriptions
+    let batch (subs: Sub<'msg> list) : Sub<'msg> =
+        List.concat subs
+
+    /// When emitting the message, map to another type.
+    /// To avoid ID conflicts with other components, scope SubIds with a prefix.
+    let map (idPrefix: string) (f: 'a -> 'msg) (sub: Sub<'a>) : Sub<'msg> =
+        sub |> List.map (fun (subId, subscribe) ->
+            idPrefix :: subId,
+            fun dispatch -> subscribe (f >> dispatch))
+
+    module Internal =
+
+        module SubId =
+
+            let toString (subId: SubId) =
+                String.Join("/", subId)
+
+        module Fx =
+
+            let warnDupe onError subId =
+                let ex = exn "Duplicate SubId"
+                onError ("Duplicate SubId: " + SubId.toString subId, ex)
+
+            let tryStop onError (subId, sub: IDisposable) =
+                try
+                    sub.Dispose()
+                with ex ->
+                    onError ("Error stopping subscription: " + SubId.toString subId, ex)
+
+            let tryStart onError dispatch (subId, start) : (SubId * IDisposable) option =
+                try
+                    Some (subId, start dispatch)
+                with ex ->
+                    onError ("Error starting subscription: " + SubId.toString subId, ex)
+                    None
+
+            let stop onError subs =
+                subs |> List.iter (tryStop onError)
+
+            let change onError dispatch (dupes, toStop, toKeep, toStart) =
+                dupes |> List.iter (warnDupe onError)
+                toStop |> List.iter (tryStop onError)
+                let started = toStart |> List.choose (tryStart onError dispatch)
+                List.append toKeep started
+
+        module NewSubs =
+
+            let (_dupes, _newKeys, _newSubs) as init =
+                List.empty, Set.empty, List.empty
+
+            let update (subId, start) (dupes, newKeys, newSubs) =
+                if Set.contains subId newKeys then
+                    subId :: dupes, newKeys, newSubs
+                else
+                    dupes, Set.add subId newKeys, (subId, start) :: newSubs
+
+            let calculate subs =
+                List.foldBack update subs init
+
+        let empty = List.empty<SubId * IDisposable>
+
+        let diff (activeSubs: (SubId * IDisposable) list) (sub: Sub<'msg>) =
+            let keys = activeSubs |> List.map fst |> Set.ofList
+            let dupes, newKeys, newSubs = NewSubs.calculate sub
+            if keys = newKeys then
+                dupes, [], activeSubs, []
+            else
+                let toKeep, toStop = activeSubs |> List.partition (fun (k, _) -> Set.contains k newKeys)
+                let toStart = newSubs |> List.filter (fun (k, _) -> not (Set.contains k keys))
+                dupes, toStop, toKeep, toStart

--- a/src/Fabulous/Sub.fs
+++ b/src/Fabulous/Sub.fs
@@ -14,59 +14,53 @@ type Sub<'msg> = (SubId * Subscribe<'msg>) list
 module Sub =
 
     /// None - no subscriptions, also known as `[]`
-    let none : Sub<'msg> =
-        []
+    let none: Sub<'msg> = []
 
     /// Aggregate multiple subscriptions
-    let batch (subs: Sub<'msg> list) : Sub<'msg> =
-        List.concat subs
+    let batch (subs: Sub<'msg> list) : Sub<'msg> = List.concat subs
 
     /// When emitting the message, map to another type.
     /// To avoid ID conflicts with other components, scope SubIds with a prefix.
     let map (idPrefix: string) (f: 'a -> 'msg) (sub: Sub<'a>) : Sub<'msg> =
-        sub |> List.map (fun (subId, subscribe) ->
-            idPrefix :: subId,
-            fun dispatch -> subscribe (f >> dispatch))
+        sub
+        |> List.map(fun (subId, subscribe) -> idPrefix :: subId, (fun dispatch -> subscribe(f >> dispatch)))
 
     module Internal =
 
         module SubId =
 
-            let toString (subId: SubId) =
-                String.Join("/", subId)
+            let toString (subId: SubId) = String.Join("/", subId)
 
         module Fx =
 
             let warnDupe onError subId =
                 let ex = exn "Duplicate SubId"
-                onError ("Duplicate SubId: " + SubId.toString subId, ex)
+                onError("Duplicate SubId: " + SubId.toString subId, ex)
 
             let tryStop onError (subId, sub: IDisposable) =
                 try
                     sub.Dispose()
                 with ex ->
-                    onError ("Error stopping subscription: " + SubId.toString subId, ex)
+                    onError("Error stopping subscription: " + SubId.toString subId, ex)
 
             let tryStart onError dispatch (subId, start) : (SubId * IDisposable) option =
                 try
-                    Some (subId, start dispatch)
+                    Some(subId, start dispatch)
                 with ex ->
-                    onError ("Error starting subscription: " + SubId.toString subId, ex)
+                    onError("Error starting subscription: " + SubId.toString subId, ex)
                     None
 
-            let stop onError subs =
-                subs |> List.iter (tryStop onError)
+            let stop onError subs = subs |> List.iter(tryStop onError)
 
             let change onError dispatch (dupes, toStop, toKeep, toStart) =
-                dupes |> List.iter (warnDupe onError)
-                toStop |> List.iter (tryStop onError)
-                let started = toStart |> List.choose (tryStart onError dispatch)
+                dupes |> List.iter(warnDupe onError)
+                toStop |> List.iter(tryStop onError)
+                let started = toStart |> List.choose(tryStart onError dispatch)
                 List.append toKeep started
 
         module NewSubs =
 
-            let (_dupes, _newKeys, _newSubs) as init =
-                List.empty, Set.empty, List.empty
+            let (_dupes, _newKeys, _newSubs) as init = List.empty, Set.empty, List.empty
 
             let update (subId, start) (dupes, newKeys, newSubs) =
                 if Set.contains subId newKeys then
@@ -74,17 +68,19 @@ module Sub =
                 else
                     dupes, Set.add subId newKeys, (subId, start) :: newSubs
 
-            let calculate subs =
-                List.foldBack update subs init
+            let calculate subs = List.foldBack update subs init
 
         let empty = List.empty<SubId * IDisposable>
 
         let diff (activeSubs: (SubId * IDisposable) list) (sub: Sub<'msg>) =
             let keys = activeSubs |> List.map fst |> Set.ofList
             let dupes, newKeys, newSubs = NewSubs.calculate sub
+
             if keys = newKeys then
                 dupes, [], activeSubs, []
             else
-                let toKeep, toStop = activeSubs |> List.partition (fun (k, _) -> Set.contains k newKeys)
-                let toStart = newSubs |> List.filter (fun (k, _) -> not (Set.contains k keys))
+                let toKeep, toStop =
+                    activeSubs |> List.partition(fun (k, _) -> Set.contains k newKeys)
+
+                let toStart = newSubs |> List.filter(fun (k, _) -> not(Set.contains k keys))
                 dupes, toStop, toKeep, toStart


### PR DESCRIPTION
New dependency tree:
```mermaid
graph TD;
    Control-->ViewNode
    ViewNode-->Events[Event handlers]
    ViewNode-->Component
    Component-->ComponentContext
    ComponentContext-->Runner
    Runner-->Subscriptions
```

When Fabulous detects a widget is removed from the view tree, it will dispose the associated ViewNode, which in turn will dispose the whole dependency tree.

We need to rely on `ViewNode.Dispose()` because frameworks like Maui doesn't provide any event telling us when a control is removed from the UI tree. The `Unloaded` event of Maui for example is called as soon as the control is no longer visible (eg we navigated to another page, but the previous page is still supposed to be alive)