### PR TITLE
Cmd throttling

### DIFF
--- a/src/Fabulous.Tests/CmdTests.fs
+++ b/src/Fabulous.Tests/CmdTests.fs
@@ -162,7 +162,7 @@ type ``Cmd tests``() =
                 messageCount <- messageCount + 1
                 dispatched <- msg :: dispatched
 
-            let batchedThrottleCmd = Cmd.batchedThrottle 100 NewValues
+            let batchedThrottleCmd, _ = Cmd.batchedThrottle 100 NewValues
 
             batchedThrottleCmd 1 |> CmdTestsHelper.execute dispatch
             batchedThrottleCmd 2 |> CmdTestsHelper.execute dispatch
@@ -186,7 +186,7 @@ type ``Cmd tests``() =
                 messageCount <- messageCount + 1
                 dispatched <- msg :: dispatched
 
-            let batchedThrottleCmd = Cmd.batchedThrottle 100 NewValues
+            let batchedThrottleCmd, _ = Cmd.batchedThrottle 100 NewValues
 
             batchedThrottleCmd 1 |> CmdTestsHelper.execute dispatch
             batchedThrottleCmd 2 |> CmdTestsHelper.execute dispatch
@@ -211,4 +211,30 @@ type ``Cmd tests``() =
             // All values should have been dispatched eventually
             Assert.AreEqual(4, messageCount)
             Assert.AreEqual([ NewValues[4]; NewValues[3]; NewValues[2]; NewValues[1] ], dispatched)
+        }
+
+    [<Test>]
+    member _.``Cmd.batchedThrottle factory can be awaited for completion``() =
+        async {
+            let mutable messageCount = 0
+            let mutable dispatched = [] // records dispatched messages latest first
+
+            let dispatch msg =
+                messageCount <- messageCount + 1
+                dispatched <- msg :: dispatched
+
+            let createCmd, awaitNextDispatch = Cmd.batchedThrottle 100 NewValues
+
+            createCmd 1 |> CmdTestsHelper.execute dispatch
+            createCmd 2 |> CmdTestsHelper.execute dispatch
+
+            // Only the first value should have been dispatched immediately
+            Assert.AreEqual(1, messageCount)
+            Assert.AreEqual([ NewValues[1] ], dispatched)
+
+            do! awaitNextDispatch None // only waits until next dispatch
+
+            // All values should have been dispatched after waiting
+            Assert.AreEqual(2, messageCount)
+            Assert.AreEqual([ NewValues[2]; NewValues[1] ], dispatched)
         }

--- a/src/Fabulous.Tests/CmdTests.fs
+++ b/src/Fabulous.Tests/CmdTests.fs
@@ -153,7 +153,7 @@ type ``Cmd tests``() =
         }
 
     [<Test>]
-    member _.``Cmd.batchedThrottle dispatches all undispatched values on interval expiry``() =
+    member _.``Dispatch.batchThrottled dispatches all undispatched values on interval expiry``() =
         async {
             let mutable messageCount = 0
             let mutable dispatched = [] // records dispatched messages latest first
@@ -162,12 +162,12 @@ type ``Cmd tests``() =
                 messageCount <- messageCount + 1
                 dispatched <- msg :: dispatched
 
-            let batchedThrottleCmd, _ = Cmd.batchedThrottle 100 NewValues
+            let batchedThrottleCmd, _ = dispatch.batchThrottled(100, NewValues)
 
-            batchedThrottleCmd 1 |> CmdTestsHelper.execute dispatch
-            batchedThrottleCmd 2 |> CmdTestsHelper.execute dispatch
-            batchedThrottleCmd 3 |> CmdTestsHelper.execute dispatch
-            batchedThrottleCmd 4 |> CmdTestsHelper.execute dispatch
+            batchedThrottleCmd 1
+            batchedThrottleCmd 2
+            batchedThrottleCmd 3
+            batchedThrottleCmd 4
 
             do! Async.Sleep 200 // Wait longer than the throttle interval
 
@@ -177,7 +177,7 @@ type ``Cmd tests``() =
         }
 
     [<Test>]
-    member _.``Cmd.batchedThrottle dispatches messages immediately if interval not expired``() =
+    member _.``Dispatch.batchThrottled dispatches messages immediately if interval not expired``() =
         async {
             let mutable messageCount = 0
             let mutable dispatched = [] // records dispatched messages latest first
@@ -186,10 +186,10 @@ type ``Cmd tests``() =
                 messageCount <- messageCount + 1
                 dispatched <- msg :: dispatched
 
-            let batchedThrottleCmd, _ = Cmd.batchedThrottle 100 NewValues
+            let batchedThrottleCmd, _ = dispatch.batchThrottled(100, NewValues)
 
-            batchedThrottleCmd 1 |> CmdTestsHelper.execute dispatch
-            batchedThrottleCmd 2 |> CmdTestsHelper.execute dispatch
+            batchedThrottleCmd 1
+            batchedThrottleCmd 2
 
             // Only the first value should have been dispatched immediately
             Assert.AreEqual(1, messageCount)
@@ -199,8 +199,8 @@ type ``Cmd tests``() =
                 giving second value time to dispatch and elapsing time until next dispatch *)
             do! Async.Sleep 210
 
-            batchedThrottleCmd 3 |> CmdTestsHelper.execute dispatch
-            batchedThrottleCmd 4 |> CmdTestsHelper.execute dispatch
+            batchedThrottleCmd 3
+            batchedThrottleCmd 4
 
             // Second value should have dispatched delayed, third immediately
             Assert.AreEqual(3, messageCount)
@@ -214,7 +214,7 @@ type ``Cmd tests``() =
         }
 
     [<Test>]
-    member _.``Cmd.batchedThrottle factory can be awaited for completion``() =
+    member _.``Dispatch.batchThrottled factory can be awaited for completion``() =
         async {
             let mutable messageCount = 0
             let mutable dispatched = [] // records dispatched messages latest first
@@ -223,10 +223,10 @@ type ``Cmd tests``() =
                 messageCount <- messageCount + 1
                 dispatched <- msg :: dispatched
 
-            let createCmd, awaitNextDispatch = Cmd.batchedThrottle 100 NewValues
+            let createCmd, awaitNextDispatch = dispatch.batchThrottled(100, NewValues)
 
-            createCmd 1 |> CmdTestsHelper.execute dispatch
-            createCmd 2 |> CmdTestsHelper.execute dispatch
+            createCmd 1
+            createCmd 2
 
             // Only the first value should have been dispatched immediately
             Assert.AreEqual(1, messageCount)

--- a/src/Fabulous.Tests/CmdTests.fs
+++ b/src/Fabulous.Tests/CmdTests.fs
@@ -13,13 +13,14 @@ module CmdTestsHelper =
 [<TestFixture>]
 type ``Cmd tests``() =
     [<Test>]
-    member _.``Cmd.debounce only dispatch the last message``() =
+    member _.``Cmd.debounce only dispatches the last messages within the timeout``() =
         async {
+            let mutable messageCount = 0
             let mutable actualValue = None
 
             let dispatch msg =
-                if actualValue.IsNone then
-                    actualValue <- Some msg
+                messageCount <- messageCount + 1
+                actualValue <- Some msg
 
             let triggerCmd = Cmd.debounce 100 NewValue
 
@@ -30,14 +31,14 @@ type ``Cmd tests``() =
             triggerCmd 3 |> CmdTestsHelper.execute dispatch
             do! Async.Sleep 125
 
+            Assert.AreEqual(1, messageCount)
             Assert.AreEqual(Some(NewValue 3), actualValue)
-
-            actualValue <- None
 
             triggerCmd 4 |> CmdTestsHelper.execute dispatch
             do! Async.Sleep 75
             triggerCmd 5 |> CmdTestsHelper.execute dispatch
             do! Async.Sleep 125
 
+            Assert.AreEqual(2, messageCount)
             Assert.AreEqual(Some(NewValue 5), actualValue)
         }

--- a/src/Fabulous.Tests/CmdTests.fs
+++ b/src/Fabulous.Tests/CmdTests.fs
@@ -42,3 +42,110 @@ type ``Cmd tests``() =
             Assert.AreEqual(2, messageCount)
             Assert.AreEqual(Some(NewValue 5), actualValue)
         }
+
+    [<Test>]
+    member _.``Cmd.throttle issues message at specified intervals``() =
+        async {
+            let mutable messageCount = 0
+            let mutable actualValue = None
+
+            let dispatch msg =
+                messageCount <- messageCount + 1
+                actualValue <- Some msg
+
+            let throttleCmd = Cmd.throttle 100 NewValue
+
+            throttleCmd 1 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 50
+            throttleCmd 2 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 75
+            throttleCmd 3 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 125
+
+            Assert.AreEqual(2, messageCount)
+            Assert.AreEqual(Some(NewValue 3), actualValue)
+
+            throttleCmd 4 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 75
+            throttleCmd 5 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 125
+
+            Assert.AreEqual(3, messageCount)
+            Assert.AreEqual(Some(NewValue 4), actualValue)
+        }
+
+    [<Test>]
+    member _.``Cmd.throttle issues only one message per interval``() =
+        async {
+            let mutable messageCount = 0
+            let mutable actualValue = None
+
+            let dispatch msg =
+                messageCount <- messageCount + 1
+                actualValue <- Some msg
+
+            let throttleCmd = Cmd.throttle 100 NewValue
+
+            throttleCmd 1 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 20
+            throttleCmd 2 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 35
+            throttleCmd 3 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 125
+
+            // Only the first message should have been dispatched
+            Assert.AreEqual(1, messageCount)
+            Assert.AreEqual(Some(NewValue 1), actualValue)
+        }
+
+    [<Test>]
+    member _.``Cmd.bufferedThrottle dispatches the first and most recent message within the specified interval``() =
+        async {
+            let mutable messageCount = 0
+            let mutable actualValue = None
+
+            let dispatch msg =
+                messageCount <- messageCount + 1
+                actualValue <- Some msg
+
+            let throttleCmd = Cmd.bufferedThrottle 100 NewValue
+
+            throttleCmd 1 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 20
+            throttleCmd 2 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 10
+            throttleCmd 3 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 20
+            throttleCmd 4 |> CmdTestsHelper.execute dispatch
+            do! Async.Sleep 125
+
+            // Only the first and most recent message should be dispatched
+            Assert.AreEqual(2, messageCount)
+            Assert.AreEqual(Some(NewValue 4), actualValue)
+        }
+
+    [<Test>]
+    member _.``Cmd.bufferedThrottle dispatches the most recent message even if delayed``() =
+        async {
+            let mutable actualValue = None
+            let mutable messageCount = 0
+
+            let dispatch msg =
+                messageCount <- messageCount + 1
+                actualValue <- Some msg
+
+            let throttleCmd = Cmd.bufferedThrottle 100 NewValue
+
+            throttleCmd 1 |> CmdTestsHelper.execute dispatch
+            throttleCmd 2 |> CmdTestsHelper.execute dispatch
+
+            // Only the first message should have been dispatched
+            Assert.AreEqual(1, messageCount)
+            Assert.AreEqual(Some(NewValue 1), actualValue)
+
+            do! Async.Sleep 200 // Wait longer than the throttle interval
+
+            // the second message should have been dispatched delayed
+            Assert.AreEqual(2, messageCount)
+            Assert.AreEqual(Some(NewValue 2), actualValue)
+        }

--- a/src/Fabulous/Cmd.fs
+++ b/src/Fabulous/Cmd.fs
@@ -325,16 +325,22 @@ module Cmd =
     /// <param name="interval">The minimum time interval between two consecutive Command executions in milliseconds.</param>
     /// <param name="fn">A function that maps a list of factory input values to a message for dispatch.</param>
     /// <returns>
-    /// A Command factory function that maps a list of input values to a Command which dispatches a message (mapped from the pending values),
+    /// Two methods - the first being a Command factory function that maps a list of input values to a Command
+    /// which dispatches a message (mapped from the pending values),
     /// either immediately or after a delay respecting the interval, while remembering and dispatching all remembered values
     /// when the interval has elapsed, ensuring no values are lost.
+    /// The second can be used for awaiting the next dispatch from the outside while adding some buffer time.
     /// </returns>
-    let batchedThrottle (interval: int) (mapValuesToMsg: 'value list -> 'msg) : 'value -> Cmd<'msg> =
+    let batchedThrottle (interval: int) (mapValuesToMsg: 'value list -> 'msg) : ('value -> Cmd<'msg>) * (System.TimeSpan option -> Async<unit>) =
         let rateLimit = System.TimeSpan.FromMilliseconds(float interval)
         let funLock = obj() // ensures safe access to resources shared across different threads
         let mutable lastDispatch = System.DateTime.MinValue
         let mutable pendingValues: 'value list = []
         let mutable cts: CancellationTokenSource = null // if set, allows cancelling the last issued Command
+
+        // gets the time to wait until the next allowed dispatch returning a negative timespan if the time is up
+        let getTimeUntilNextDispatch () =
+            lastDispatch.Add(rateLimit) - System.DateTime.UtcNow
 
         // dispatches all pendingValues and resets them while updating lastDispatch
         let dispatchBatch (dispatch: 'msg -> unit) =
@@ -344,39 +350,57 @@ module Cmd =
             lastDispatch <- System.DateTime.UtcNow
             pendingValues <- []
 
-        // Return a factory function mapping input values to sleeping Commands dispatching all pending messages
-        fun (value: 'value) ->
-            [ fun dispatch ->
-                  lock funLock (fun () ->
-                      let now = System.DateTime.UtcNow
-                      let elapsedSinceLastDispatch = now - lastDispatch
-                      pendingValues <- value :: pendingValues
+        // a factory function mapping input values to sleeping Commands dispatching all pending messages
+        let factory =
+            fun (value: 'value) ->
+                [ fun dispatch ->
+                      lock funLock (fun () ->
+                          let untilNextDispatch = getTimeUntilNextDispatch()
+                          pendingValues <- value :: pendingValues
 
-                      // If the interval has elapsed since the last dispatch, dispatch all pending messages
-                      if elapsedSinceLastDispatch >= rateLimit then
-                          dispatchBatch dispatch
-                      else // schedule dispatch
+                          // If the interval has elapsed since the last dispatch, dispatch all pending messages
+                          if untilNextDispatch <= System.TimeSpan.Zero then
+                              dispatchBatch dispatch
+                          else // schedule dispatch
 
-                          // if the the last sleeping dispatch can still be cancelled, do so
-                          if cts <> null then
-                              cts.Cancel()
-                              cts.Dispose()
+                              // if the the last sleeping dispatch can still be cancelled, do so
+                              if cts <> null then
+                                  cts.Cancel()
+                                  cts.Dispose()
 
-                          // used to enable cancelling this dispatch if newer values come into the factory
-                          cts <- new CancellationTokenSource()
+                              // used to enable cancelling this dispatch if newer values come into the factory
+                              cts <- new CancellationTokenSource()
 
-                          Async.Start(
-                              async {
-                                  // wait only as long as we have to before next dispatch
-                                  do! Async.Sleep(rateLimit - elapsedSinceLastDispatch)
+                              Async.Start(
+                                  async {
+                                      // wait only as long as we have to before next dispatch
+                                      do! Async.Sleep(untilNextDispatch)
 
-                                  lock funLock (fun () ->
-                                      dispatchBatch dispatch
+                                      lock funLock (fun () ->
+                                          dispatchBatch dispatch
 
-                                      // done; invalidate own cancellation
-                                      if cts <> null then
-                                          cts.Dispose()
-                                          cts <- null)
-                              },
-                              cts.Token
-                          )) ]
+                                          // done; invalidate own cancellation
+                                          if cts <> null then
+                                              cts.Dispose()
+                                              cts <- null)
+                                  },
+                                  cts.Token
+                              )) ]
+
+        // a function to wait until after the next async dispatch + some buffer time to ensure the dispatch is complete
+        let awaitNextDispatch buffer =
+            lock funLock (fun () ->
+                async {
+                    if not pendingValues.IsEmpty then
+                        let untilAfterNextDispatch =
+                            getTimeUntilNextDispatch()
+                            + match buffer with
+                              | Some value -> value
+                              | None -> System.TimeSpan.Zero
+
+                        if untilAfterNextDispatch > System.TimeSpan.Zero then
+                            do! Async.Sleep(untilAfterNextDispatch)
+                })
+
+        // return both the factory and the await helper
+        factory, awaitNextDispatch


### PR DESCRIPTION
- improving **debounce** test and doco to warn against misuse
- **adding** command factories for throttling and buffered throttling (guaranteeing the last message is dispatched)

The throttling methods are intended for stuff like throttling `Progress<>` updates from background tasks like the following search does while yielding results from an `IAsyncEnumerable`: 

```fsharp

    let private searchCmd model =
        fun dispatch ->
            async {
                let command = mapToSearchCommand model
                
                let dispatchProgress = Cmd.bufferedThrottle 100 (fun progress ->
                    System.Diagnostics.Debug.WriteLine("progress dispatched " + progress.ToString())
                    SearchProgress progress)
                    
                let reporter = Progress<BatchProgress>(fun progress ->
                    System.Diagnostics.Debug.WriteLine("progress reported" + progress.ToString())
                    dispatchProgress progress
                        // dispatch messages from returned command
                        |> List.iter (fun effect -> effect dispatch))
                
                use cts = new CancellationTokenSource()

                do! searchAsync(command, reporter, cts.Token)
                    // yield results from IAsyncEnumerable as they're available, see https://github.com/fsprojects/FSharp.Control.TaskSeq
                    |> TaskSeq.iter (fun result -> SearchResult result |> dispatch)
                    |> Async.AwaitTask

                dispatch SearchCompleted
            } |> Async.StartImmediate
        |> Cmd.ofEffect
```

I'm a Fabulous and F# freshie, so please have a good hard look at my changes and above intended use case. Feel free to point out anything that looks weird or cumbersome to you - I'm here to learn :)