### PR TITLE
Include Memo.KeyData in CanReuseMemo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes_
 
+## [2.4.2] - 2024-03-04
+
+### Changed
+- Include Memo.KeyData in CanReuseMemo by @TimLariviere (https://github.com/fabulous-dev/Fabulous/pull/1071)
+
 ## [2.4.1] - 2024-01-29
 
 ### Added
@@ -55,7 +60,8 @@ _No unreleased changes_
 ### Changed
 - Fabulous.XamarinForms & Fabulous.MauiControls have been moved been out of the Fabulous repository. Find them in their own repositories: [https://github.com/fabulous-dev/Fabulous.XamarinForms](https://github.com/fabulous-dev/Fabulous.XamarinForms) / [https://github.com/fabulous-dev/Fabulous.MauiControls](https://github.com/fabulous-dev/Fabulous.MauiControls)
 
-[unreleased]: https://github.com/fabulous-dev/Fabulous/compare/2.4.1...HEAD
+[unreleased]: https://github.com/fabulous-dev/Fabulous/compare/2.4.2...HEAD
+[2.4.2]: https://github.com/fabulous-dev/Fabulous/releases/tag/2.4.2
 [2.4.1]: https://github.com/fabulous-dev/Fabulous/releases/tag/2.4.1
 [2.4.0]: https://github.com/fabulous-dev/Fabulous/releases/tag/2.4.0
 [2.3.2]: https://github.com/fabulous-dev/Fabulous/releases/tag/2.3.2

--- a/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
@@ -445,6 +445,7 @@ module MemoTests =
             instance.ProcessMessage(SetMemoPart 99)
 
             // rerendered because of memo key changed
+            let memoLabel = find<TestLabel> tree "memo" :> IText
             Assert.AreEqual(2, renderCount)
             Assert.AreEqual("99", memoLabel.Text)
 
@@ -534,11 +535,11 @@ module MemoTests =
 
             let labelAgain = find<TestLabel> tree "label"
 
-            // same instance
-            Assert.AreSame(label, labelAgain)
+            // not same instance
+            Assert.AreNotSame(label, labelAgain)
 
             // just changes text but kept the same color
-            Assert.AreEqual([ TextSet "one"; ColorSet "blue"; TextSet "two" ], label.changeList)
+            Assert.AreEqual([ TextSet "two"; ColorSet "blue" ], labelAgain.changeList)
 
 
 

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -59,7 +59,11 @@ module Memo =
         | _ -> failwith "Memo widget cannot have extra attributes"
 
     let internal canReuseMemoizedWidget prev next =
-        (getMemoData prev).MarkerType = (getMemoData next).MarkerType
+        let prevMemoData = getMemoData prev
+        let currMemoData = getMemoData next
+        
+        prevMemoData.MarkerType = currMemoData.MarkerType
+        && prevMemoData.KeyData = currMemoData.KeyData
 
     let internal MemoAttribute: SimpleScalarAttributeDefinition<MemoData> =
         { Key = MemoAttributeKey

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -61,7 +61,7 @@ module Memo =
     let internal canReuseMemoizedWidget prev next =
         let prevMemoData = getMemoData prev
         let currMemoData = getMemoData next
-        
+
         prevMemoData.MarkerType = currMemoData.MarkerType
         && prevMemoData.KeyData = currMemoData.KeyData
 


### PR DESCRIPTION
To determine if a Memo widget can be reused between updates, we were only checking the type of the root widget (eg. VStack). This led to issues when a Memo widget is replaced by another Memo widget with the same root widget type but with different AutomationId.

To improve this a little bit, we also need to include the check between Memo.KeyData as 2 Memo widgets will most likely have different KeyData.