### PR TITLE
Add support for Binding in Components

### DIFF
--- a/src/Fabulous/Binding.fs
+++ b/src/Fabulous/Binding.fs
@@ -48,9 +48,11 @@ type BindingExtensions =
             | ValueSome d -> d.Dispose()
 
             // Subscribe to source context changes
+            let sourceKey = stateValue.Key
+
             let sub =
                 stateValue.Context.RenderNeeded.Subscribe(fun k ->
-                    if k = stateValue.Key then
+                    if k = sourceKey then
                         ctx.NeedsRender(key))
 
             ctx.SetValueInternal(key, sub)

--- a/src/Fabulous/Binding.fs
+++ b/src/Fabulous/Binding.fs
@@ -1,0 +1,59 @@
+namespace Fabulous
+
+open System
+open System.ComponentModel
+open System.Runtime.CompilerServices
+
+type BindingRequest<'T> = delegate of unit -> StateValue<'T>
+
+[<Struct>]
+type BindingValue<'T> =
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    val public SourceContext: ComponentContext
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    val public SourceKey: int
+
+    new(stateValue: StateValue<'T>) =
+        { SourceContext = stateValue.Context
+          SourceKey = stateValue.Key }
+
+    member this.Current = this.SourceContext.TryGetValue<'T>(this.SourceKey).Value
+
+    member inline this.Set(value: 'T) =
+        this.SourceContext.SetValue(this.SourceKey, value)
+
+[<AutoOpen>]
+module BindingBuilders =
+    type Context with
+
+        static member inline Binding(value: StateValue<'T>) = BindingRequest<'T>(fun () -> value)
+
+[<Extension>]
+type BindingExtensions =
+    [<Extension>]
+    static member inline Bind
+        (
+            _: ComponentBuilder<'parentMsg>,
+            [<InlineIfLambda>] fn: BindingRequest<'T>,
+            [<InlineIfLambda>] continuation: BindingValue<'T> -> ComponentBodyBuilder<'marker>
+        ) =
+        ComponentBodyBuilder<'marker>(fun bindings ctx ->
+            let key = int bindings
+            let stateValue = fn.Invoke()
+
+            // Dispose previous subscription
+            match ctx.TryGetValue<IDisposable>(key) with
+            | ValueNone -> ()
+            | ValueSome d -> d.Dispose()
+
+            // Subscribe to source context changes
+            let sub =
+                stateValue.Context.RenderNeeded.Subscribe(fun k ->
+                    if k = stateValue.Key then
+                        ctx.NeedsRender(key))
+
+            ctx.SetValueInternal(key, sub)
+
+            let bindingValue = BindingValue<'T>(stateValue)
+            (continuation bindingValue).Invoke(bindings, ctx))

--- a/src/Fabulous/Component.fs
+++ b/src/Fabulous/Component.fs
@@ -332,7 +332,7 @@ type Component(treeContext: ViewTreeContext, body: ComponentBody, context: Compo
     interface IDisposable with
         member this.Dispose() = this.Dispose()
 
-    member this.Render() =
+    member this.Render(_) =
         treeContext.SyncAction(this.RenderInternal)
 
 module Component =

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -43,6 +43,7 @@
     <Compile Include="ComponentContext.fs" />
     <Compile Include="Component.fs" />
     <Compile Include="State.fs" />
+    <Compile Include="Binding.fs" />
     <Compile Include="MvuComponent.fs" />
     <Compile Include="Memo.fs" />
     <Compile Include="View.fs" />


### PR DESCRIPTION
Components only supports local state through the use of `Context.State(defaultValue)`. 
With `Context.Binding(stateValue)`, a component can take a dependency on the local state of another component and be able to listen to changes as well as update the value, triggering a refresh of both components.

Usage:
```fs
// Children
let firstNameView (value: StateValue<string>) =
    Component() {
        let! firstName = Context.Binding(value)
        Entry(firstName.Current, firstName.Set)
    }

let lastNameView (value: StateValue<string>) =
    Component() {
        let! lastName = Context.Binding(value)
        Entry(lastName.Current, lastName.Set)
    }

// Parent
let parentView () =
    Component() {
        // Parent is the one owning the data
        let! firstName = Context.State("")
        let! lastName = Context.State("")

        VStack() {
            Label($"Full name is {firstName.Current} {lastName.Current}")
            firstNameView firstName
            lastNameView lastName
    }
```