### PR TITLE
Find the component data key in the attribute keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes_
 
+## [3.0.0-pre3] - 2024-04-12
+
+### Changed
+- Find the component data key in the attribute keys (https://github.com/fabulous-dev/Fabulous/pull/1075)
+
 ## [3.0.0-pre2] - 2024-03-025
 
 ### Added
@@ -120,7 +125,8 @@ _No unreleased changes_
 ### Changed
 - Fabulous.XamarinForms & Fabulous.MauiControls have been moved been out of the Fabulous repository. Find them in their own repositories: [https://github.com/fabulous-dev/Fabulous.XamarinForms](https://github.com/fabulous-dev/Fabulous.XamarinForms) / [https://github.com/fabulous-dev/Fabulous.MauiControls](https://github.com/fabulous-dev/Fabulous.MauiControls)
 
-[unreleased]: https://github.com/fabulous-dev/Fabulous/compare/3.0.0-pre2...HEAD
+[unreleased]: https://github.com/fabulous-dev/Fabulous/compare/3.0.0-pre3...HEAD
+[3.0.0-pre3]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre3
 [3.0.0-pre2]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre2
 [3.0.0-pre1]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre1
 [2.5.0-pre11]: https://github.com/fabulous-dev/Fabulous/releases/tag/2.5.0-pre11

--- a/src/Fabulous/Component.fs
+++ b/src/Fabulous/Component.fs
@@ -354,6 +354,7 @@ module Component =
                         let data =
                             let scalarAttrsOpt =
                                 attrs |> Array.tryFind(fun scalarAttr -> scalarAttr.Key = Data.Key)
+
                             match scalarAttrsOpt with
                             | Some attr -> attr.Value :?> ComponentData
                             | None -> failwith "Component widget must have a body"
@@ -371,7 +372,10 @@ module Component =
                     | ValueNone -> failwith "Component widget must have a body"
                     | ValueSome attrs ->
                         let data =
-                            match Array.tryHead attrs with
+                            let scalarAttrsOpt =
+                                attrs |> Array.tryFind(fun scalarAttr -> scalarAttr.Key = Data.Key)
+
+                            match scalarAttrsOpt with
                             | Some attr -> attr.Value :?> ComponentData
                             | None -> failwith "Component widget must have a body"
 

--- a/src/Fabulous/Component.fs
+++ b/src/Fabulous/Component.fs
@@ -336,6 +336,9 @@ type Component(treeContext: ViewTreeContext, body: ComponentBody, context: Compo
         treeContext.SyncAction(this.RenderInternal)
 
 module Component =
+    let Data =
+        Attributes.defineSimpleScalar<ComponentData> "Component_Data" ScalarAttributeComparers.noCompare (fun _ _ _ -> ())
+
     let WidgetKey =
         let key = WidgetDefinitionStore.getNextKey()
 
@@ -349,7 +352,9 @@ module Component =
                     | ValueNone -> failwith "Component widget must have a body"
                     | ValueSome attrs ->
                         let data =
-                            match Array.tryHead attrs with
+                            let scalarAttrsOpt =
+                                attrs |> Array.tryFind(fun scalarAttr -> scalarAttr.Key = Data.Key)
+                            match scalarAttrsOpt with
                             | Some attr -> attr.Value :?> ComponentData
                             | None -> failwith "Component widget must have a body"
 
@@ -380,9 +385,6 @@ module Component =
 
         WidgetDefinitionStore.set key definition
         key
-
-    let Data =
-        Attributes.defineSimpleScalar<ComponentData> "Component_Data" ScalarAttributeComparers.noCompare (fun _ _ _ -> ())
 
 /// Delegate used by the ComponentBuilder to compose a component body
 /// It will be aggressively inlined by the compiler leaving no overhead, only a pure function that returns a WidgetBuilder

--- a/src/Fabulous/MvuComponent.fs
+++ b/src/Fabulous/MvuComponent.fs
@@ -10,6 +10,9 @@ type MvuComponentData =
       Arg: obj }
 
 module MvuComponent =
+    let Data =
+        Attributes.defineSimpleScalar<MvuComponentData> "MvuComponent_Data" ScalarAttributeComparers.noCompare (fun _ _ _ -> ())
+
     let WidgetKey =
         let key = WidgetDefinitionStore.getNextKey()
 
@@ -59,7 +62,10 @@ module MvuComponent =
                     | ValueNone -> failwith "Component widget must have a body"
                     | ValueSome attrs ->
                         let data =
-                            match Array.tryHead attrs with
+                            let scalarAttrsOpt =
+                                attrs |> Array.tryFind(fun scalarAttr -> scalarAttr.Key = Data.Key)
+
+                            match scalarAttrsOpt with
                             | Some attr -> attr.Value :?> MvuComponentData
                             | None -> failwith "Component widget must have a body"
 
@@ -86,9 +92,6 @@ module MvuComponent =
 
         WidgetDefinitionStore.set key definition
         key
-
-    let Data =
-        Attributes.defineSimpleScalar<MvuComponentData> "MvuComponent_Data" ScalarAttributeComparers.noCompare (fun _ _ _ -> ())
 
     let canReuseMvuComponent (prev: Widget) (curr: Widget) =
         let prevData =

--- a/src/Fabulous/MvuComponent.fs
+++ b/src/Fabulous/MvuComponent.fs
@@ -26,7 +26,10 @@ module MvuComponent =
                     | ValueNone -> failwith "Component widget must have a body"
                     | ValueSome attrs ->
                         let data =
-                            match Array.tryHead attrs with
+                            let scalarAttrsOpt =
+                                attrs |> Array.tryFind(fun scalarAttr -> scalarAttr.Key = Data.Key)
+
+                            match scalarAttrsOpt with
                             | Some attr -> attr.Value :?> MvuComponentData
                             | None -> failwith "Component widget must have a body"
 


### PR DESCRIPTION
Before we assumed that the component data key was always the first in the array and we were using `tryHead`. Now we use `tryFind`