### PR TITLE
Add new `CollectionBuilder` constructor using an `AttributesBundle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes_
 
+## [3.0.0-pre5] - 2024-05-17
+
+### Added
+- Add new `CollectionBuilder` constructor using an `AttributesBundle` by @edgarfgp in https://github.com/fabulous-dev/Fabulous/pull/1081
+
 ## [3.0.0-pre4] - 2024-04-19
 
 ### Added
@@ -134,7 +139,8 @@ _No unreleased changes_
 ### Changed
 - Fabulous.XamarinForms & Fabulous.MauiControls have been moved been out of the Fabulous repository. Find them in their own repositories: [https://github.com/fabulous-dev/Fabulous.XamarinForms](https://github.com/fabulous-dev/Fabulous.XamarinForms) / [https://github.com/fabulous-dev/Fabulous.MauiControls](https://github.com/fabulous-dev/Fabulous.MauiControls)
 
-[unreleased]: https://github.com/fabulous-dev/Fabulous/compare/3.0.0-pre4...HEAD
+[unreleased]: https://github.com/fabulous-dev/Fabulous/compare/3.0.0-pre5...HEAD
+[3.0.0-pre5]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre5
 [3.0.0-pre4]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre4
 [3.0.0-pre3]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre3
 [3.0.0-pre2]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre2

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -155,11 +155,7 @@ module TestUI_Widgets =
             )
 
         static member Stack<'msg, 'marker when 'marker :> IMarker>() =
-            CollectionBuilder<'msg, TestStackMarker, 'marker>(
-                TestStackKey,
-                Attributes.Container.Children,
-                AttributesBundle(StackList.empty(), ValueNone, ValueNone)
-            )
+            CollectionBuilder<'msg, TestStackMarker, 'marker>(TestStackKey, StackList.empty(), Attributes.Container.Children)
 
     [<Extension>]
     type CollectionBuilderExtensions =

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -155,9 +155,11 @@ module TestUI_Widgets =
             )
 
         static member Stack<'msg, 'marker when 'marker :> IMarker>() =
-            CollectionBuilder<'msg, TestStackMarker, 'marker>(TestStackKey, StackList.empty(), Attributes.Container.Children)
-
-
+            CollectionBuilder<'msg, TestStackMarker, 'marker>(
+                TestStackKey,
+                Attributes.Container.Children,
+                AttributesBundle(StackList.empty(), ValueNone, ValueNone)
+            )
 
     [<Extension>]
     type CollectionBuilderExtensions =

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -128,33 +128,33 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
         val Attr: WidgetCollectionAttributeDefinition
         val Attributes: AttributesBundle
 
-        new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, attributes: AttributesBundle) =
+        new(widgetKey: WidgetKey, scalars: StackList<ScalarAttribute>, attr: WidgetCollectionAttributeDefinition) =
             { WidgetKey = widgetKey
-              Attr = attr
-              Attributes = attributes }
-              
-        new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, scalars: StackList<ScalarAttribute>) =
-            { WidgetKey = widgetKey
-              Attr = attr
-              Attributes = AttributesBundle(scalars, ValueNone, ValueNone) }
+              Attributes = AttributesBundle(scalars, ValueNone, ValueNone)
+              Attr = attr }
 
         new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition) =
             { WidgetKey = widgetKey
-              Scalars = AttributesBundle(StackList.empty(), ValueNone, ValueNone)
+              Attributes = AttributesBundle(StackList.empty(), ValueNone, ValueNone)
+              Attr = attr }
+
+        new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, attributes: AttributesBundle) =
+            { WidgetKey = widgetKey
+              Attributes = attributes
               Attr = attr }
 
         new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, scalar: ScalarAttribute) =
             { WidgetKey = widgetKey
-              Scalars = AttributesBundle(StackList.one scalar, ValueNone, ValueNone)
+              Attributes = AttributesBundle(StackList.one scalar, ValueNone, ValueNone)
               Attr = attr }
 
         new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, scalarA: ScalarAttribute, scalarB: ScalarAttribute) =
             { WidgetKey = widgetKey
-              Scalars = AttributesBundle(StackList.two(scalarA, scalarB), ValueNone, ValueNone)
+              Attributes = AttributesBundle(StackList.two(scalarA, scalarB), ValueNone, ValueNone)
               Attr = attr }
 
         member inline x.Run(c: Content<'msg>) =
-            let struct (scalars, widgets, widgetCollections) = x.Scalars
+            let struct (scalars, widgets, widgetCollections) = x.Attributes
 
             let attrValue =
                 match MutStackArray1.toArraySlice &c.Widgets with
@@ -192,7 +192,7 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
         [<EditorBrowsable(EditorBrowsableState.Never)>]
         member inline x.AddScalar(attr: ScalarAttribute) =
             let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) =
-                x.Scalars
+                x.Attributes
 
             CollectionBuilder<'msg, 'marker, 'itemMarker>(
                 x.WidgetKey,

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -128,10 +128,15 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
         val Attr: WidgetCollectionAttributeDefinition
         val Attributes: AttributesBundle
 
-        new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, scalars: AttributesBundle) =
+        new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, attributes: AttributesBundle) =
             { WidgetKey = widgetKey
-              Scalars = scalars
-              Attr = attr }
+              Attr = attr
+              Attributes = attributes }
+              
+        new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, scalars: StackList<ScalarAttribute>) =
+            { WidgetKey = widgetKey
+              Attr = attr
+              Attributes = AttributesBundle(scalars, ValueNone, ValueNone) }
 
         new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition) =
             { WidgetKey = widgetKey

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -126,7 +126,7 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
     struct
         val WidgetKey: WidgetKey
         val Attr: WidgetCollectionAttributeDefinition
-        val Scalars: AttributesBundle
+        val Attributes: AttributesBundle
 
         new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, scalars: AttributesBundle) =
             { WidgetKey = widgetKey


### PR DESCRIPTION
Currently in Fabulous you can't pass a `WidgetBuilder` as part of the `CollectionBuilder` constructor using `AttributesBundle`.

### Before

<img width="936" alt="Screenshot 2024-05-13 at 21 23 58" src="https://github.com/fabulous-dev/Fabulous/assets/31915729/13058f74-e755-4e74-96a7-0e534aec5319">

### After

![Screenshot 2024-05-13 at 22 10 57](https://github.com/fabulous-dev/Fabulous/assets/31915729/52931a3d-186a-4696-bd21-7bd132bb2a8f)


This PR changes the `CollectionBuilder` definition to use `AttributesBundle`.