### PR TITLE
Add equality constraint on 'msg to prevent confusion with new non-MVU modifiers

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,10 +3,11 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "6.2.3",
+      "version": "6.3.15",
       "commands": [
         "fantomas"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes_
 
+## [3.0.0-pre6] - 2024-09-24
+
+### Changed
+- Add equality constraint on 'msg to prevent confusion with new non-MVU modifiers by @TimLariviere https://github.com/fabulous-dev/Fabulous/pull/1084
+
+### Added
+- Add new `CollectionBuilder` constructor using an `AttributesBundle` by @edgarfgp in https://github.com/fabulous-dev/Fabulous/pull/1081
+
 ## [3.0.0-pre5] - 2024-05-17
 
 ### Added
@@ -139,7 +147,8 @@ _No unreleased changes_
 ### Changed
 - Fabulous.XamarinForms & Fabulous.MauiControls have been moved been out of the Fabulous repository. Find them in their own repositories: [https://github.com/fabulous-dev/Fabulous.XamarinForms](https://github.com/fabulous-dev/Fabulous.XamarinForms) / [https://github.com/fabulous-dev/Fabulous.MauiControls](https://github.com/fabulous-dev/Fabulous.MauiControls)
 
-[unreleased]: https://github.com/fabulous-dev/Fabulous/compare/3.0.0-pre5...HEAD
+[unreleased]: https://github.com/fabulous-dev/Fabulous/compare/3.0.0-pre6...HEAD
+[3.0.0-pre6]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre6
 [3.0.0-pre5]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre5
 [3.0.0-pre4]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre4
 [3.0.0-pre3]: https://github.com/fabulous-dev/Fabulous/releases/tag/3.0.0-pre3

--- a/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
@@ -642,29 +642,29 @@ module Issue104 =
 
     let ControlWidgetKey = Widgets.register<TestButton>()
 
-    let Control<'msg> () =
+    let Control () =
         WidgetBuilder<'msg, TestButtonMarker>(ControlWidgetKey, AttributesBundle(StackList.StackList.empty(), ValueNone, ValueNone))
 
     [<System.Runtime.CompilerServices.Extension>]
     type WidgetExtensions() =
         [<System.Runtime.CompilerServices.Extension>]
-        static member inline attr1<'msg, 'marker when 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
+        static member inline attr1<'msg, 'marker when 'msg: equality and 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
             this.AddScalar(Attr1.WithValue(value))
 
         [<System.Runtime.CompilerServices.Extension>]
-        static member inline attr2<'msg, 'marker when 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
+        static member inline attr2<'msg, 'marker when 'msg: equality and 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
             this.AddScalar(Attr2.WithValue(value))
 
         [<System.Runtime.CompilerServices.Extension>]
-        static member inline attr3<'msg, 'marker when 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
+        static member inline attr3<'msg, 'marker when 'msg: equality and 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
             this.AddScalar(Attr3.WithValue(value))
 
         [<System.Runtime.CompilerServices.Extension>]
-        static member inline attr4<'msg, 'marker when 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
+        static member inline attr4<'msg, 'marker when 'msg: equality and 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
             this.AddScalar(Attr4.WithValue(value))
 
         [<System.Runtime.CompilerServices.Extension>]
-        static member inline attr5<'msg, 'marker when 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
+        static member inline attr5<'msg, 'marker when 'msg: equality and 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
             this.AddScalar(Attr5.WithValue(value))
 
     let view model =

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -82,37 +82,37 @@ module TestUI_Widgets =
     [<Extension>]
     type WidgetExtensions() =
         [<Extension>]
-        static member inline automationId<'msg, 'marker when 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
+        static member inline automationId<'msg, 'marker when 'msg: equality and 'marker :> IMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
             this.AddScalar(Attributes.Automation.AutomationId.WithValue(value))
 
         [<Extension>]
-        static member inline automationId<'msg, 'marker, 'itemMarker when 'marker :> IMarker>
+        static member inline automationId<'msg, 'marker, 'itemMarker when 'msg: equality and 'marker :> IMarker>
             (this: CollectionBuilder<'msg, 'marker, 'itemMarker>, value: string)
             =
             this.AddScalar(Attributes.Automation.AutomationId.WithValue(value))
 
         [<Extension>]
-        static member inline textColor<'msg, 'marker when 'marker :> TextMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
+        static member inline textColor<'msg, 'marker when 'msg: equality and 'marker :> TextMarker>(this: WidgetBuilder<'msg, 'marker>, value: string) =
             this.AddScalar(Attributes.TextStyle.TextColor.WithValue(value))
 
 
         [<Extension>]
-        static member inline record<'msg, 'marker when 'marker :> TestLabelMarker>(this: WidgetBuilder<'msg, 'marker>, value: bool) =
+        static member inline record<'msg, 'marker when 'msg: equality and 'marker :> TestLabelMarker>(this: WidgetBuilder<'msg, 'marker>, value: bool) =
             this.AddScalar(Attributes.Text.Record.WithValue(value))
 
 
         [<Extension>]
-        static member inline tap<'msg, 'marker when 'marker :> TestButtonMarker>(this: WidgetBuilder<'msg, 'marker>, value: 'msg) =
+        static member inline tap<'msg, 'marker when 'msg: equality and 'marker :> TestButtonMarker>(this: WidgetBuilder<'msg, 'marker>, value: 'msg) =
             this.AddScalar(Attributes.Button.Tap.WithValue(value))
 
 
         [<Extension>]
-        static member inline tap2<'msg, 'marker when 'marker :> TestButtonMarker>(this: WidgetBuilder<'msg, 'marker>, value: 'msg) =
+        static member inline tap2<'msg, 'marker when 'msg: equality and 'marker :> TestButtonMarker>(this: WidgetBuilder<'msg, 'marker>, value: 'msg) =
             this.AddScalar(Attributes.Button.Tap2.WithValue(value))
 
 
         [<Extension>]
-        static member inline tapContainer<'msg, 'marker when 'marker :> TestStackMarker>(this: WidgetBuilder<'msg, 'marker>, value: 'msg) =
+        static member inline tapContainer<'msg, 'marker when 'msg: equality and 'marker :> TestStackMarker>(this: WidgetBuilder<'msg, 'marker>, value: 'msg) =
             this.AddScalar(Attributes.Container.Tap.WithValue(value))
 
     ///----------------
@@ -125,14 +125,14 @@ module TestUI_Widgets =
         static let TestStackKey = Widgets.register<TestStack>()
         static let TestNumericBagKey = Widgets.register<TestNumericBag>()
 
-        static member Label<'msg>(text: string) =
+        static member Label(text: string) =
             WidgetBuilder<'msg, TestLabelMarker>(TestLabelKey, Attributes.Text.Text.WithValue(text))
 
 
-        static member Button<'msg>(text: string, onClicked: 'msg) =
+        static member Button(text: string, onClicked: 'msg) =
             WidgetBuilder<'msg, TestButtonMarker>(TestButtonKey, Attributes.Text.Text.WithValue(text), Attributes.Button.Pressed.WithValue(onClicked))
 
-        static member BoxedNumericBag<'msg>(one, two, three) =
+        static member BoxedNumericBag(one, two, three) =
             WidgetBuilder<'msg, TestNumericBagMarker>(
                 TestNumericBagKey,
                 Attributes.NumericBag.BoxedValueOne.WithValue(one),
@@ -140,7 +140,7 @@ module TestUI_Widgets =
                 Attributes.NumericBag.BoxedValueThree.WithValue(three)
             )
 
-        static member InlineNumericBag<'msg>(one, two, three) =
+        static member InlineNumericBag(one, two, three) =
             WidgetBuilder<'msg, TestNumericBagMarker>(
                 TestNumericBagKey,
                 Attributes.NumericBag.InlineValueOne.WithValue(one, (fun x -> x)),
@@ -150,25 +150,25 @@ module TestUI_Widgets =
                 Attributes.NumericBag.InlineValueThree.WithValue(three, BitConverter.DoubleToUInt64Bits)
             )
 
-        static member Stack<'msg, 'marker when 'marker :> IMarker>() =
+        static member Stack<'msg, 'marker when 'msg: equality and 'marker :> IMarker>() =
             CollectionBuilder<'msg, TestStackMarker, 'marker>(TestStackKey, StackList.empty(), Attributes.Container.Children)
 
     [<Extension>]
     type CollectionBuilderExtensions =
         [<Extension>]
-        static member inline Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
+        static member inline Yield<'msg, 'marker, 'itemMarker when 'msg: equality and 'itemMarker :> IMarker>
             (_: CollectionBuilder<'msg, 'marker, IMarker>, x: WidgetBuilder<'msg, 'itemMarker>)
             : Content<'msg> =
             CollectionBuilder.yieldImpl x
 
         [<Extension>]
-        static member inline Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
+        static member inline Yield<'msg, 'marker, 'itemMarker when 'msg: equality and 'itemMarker :> IMarker>
             (_: CollectionBuilder<'msg, 'marker, IMarker>, x: WidgetBuilder<'msg, Memo.Memoized<'itemMarker>>)
             : Content<'msg> =
             CollectionBuilder.yieldImpl x
 
         [<Extension>]
-        static member inline YieldFrom<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
+        static member inline YieldFrom<'msg, 'marker, 'itemMarker when 'msg: equality and 'itemMarker :> IMarker>
             (_: CollectionBuilder<'msg, 'marker, IMarker>, x: WidgetBuilder<'msg, 'itemMarker> seq)
             : Content<'msg> =
             // TODO optimize this one with addMut
@@ -178,7 +178,7 @@ module TestUI_Widgets =
 
 
     ///------------------
-    type StatefulView<'arg, 'model, 'msg, 'marker> =
+    type StatefulView<'arg, 'model, 'msg, 'marker when 'msg: equality> =
         { Init: 'arg -> 'model
           Update: 'msg -> 'model -> 'model
           View: 'model -> WidgetBuilder<'msg, 'marker> }
@@ -191,7 +191,7 @@ module TestUI_Widgets =
 
 
     module Run =
-        type Instance<'arg, 'model, 'msg, 'marker>(program: StatefulView<'arg, 'model, 'msg, 'marker>) =
+        type Instance<'arg, 'model, 'msg, 'marker when 'msg: equality>(program: StatefulView<'arg, 'model, 'msg, 'marker>) =
             let mutable state: ('model * obj * Widget) option = None
 
             member private x.viewContext: ViewTreeContext =

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -59,9 +59,7 @@ module TestUI_Widgets =
 
 
     //-----MARKERS-----------
-    type IMarker =
-        interface
-        end
+    type IMarker = interface end
 
     type TextMarker =
         inherit IMarker
@@ -89,10 +87,8 @@ module TestUI_Widgets =
 
         [<Extension>]
         static member inline automationId<'msg, 'marker, 'itemMarker when 'marker :> IMarker>
-            (
-                this: CollectionBuilder<'msg, 'marker, 'itemMarker>,
-                value: string
-            ) =
+            (this: CollectionBuilder<'msg, 'marker, 'itemMarker>, value: string)
+            =
             this.AddScalar(Attributes.Automation.AutomationId.WithValue(value))
 
         [<Extension>]
@@ -161,26 +157,20 @@ module TestUI_Widgets =
     type CollectionBuilderExtensions =
         [<Extension>]
         static member inline Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
-            (
-                _: CollectionBuilder<'msg, 'marker, IMarker>,
-                x: WidgetBuilder<'msg, 'itemMarker>
-            ) : Content<'msg> =
+            (_: CollectionBuilder<'msg, 'marker, IMarker>, x: WidgetBuilder<'msg, 'itemMarker>)
+            : Content<'msg> =
             CollectionBuilder.yieldImpl x
 
         [<Extension>]
         static member inline Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
-            (
-                _: CollectionBuilder<'msg, 'marker, IMarker>,
-                x: WidgetBuilder<'msg, Memo.Memoized<'itemMarker>>
-            ) : Content<'msg> =
+            (_: CollectionBuilder<'msg, 'marker, IMarker>, x: WidgetBuilder<'msg, Memo.Memoized<'itemMarker>>)
+            : Content<'msg> =
             CollectionBuilder.yieldImpl x
 
         [<Extension>]
         static member inline YieldFrom<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
-            (
-                _: CollectionBuilder<'msg, 'marker, IMarker>,
-                x: WidgetBuilder<'msg, 'itemMarker> seq
-            ) : Content<'msg> =
+            (_: CollectionBuilder<'msg, 'marker, IMarker>, x: WidgetBuilder<'msg, 'itemMarker> seq)
+            : Content<'msg> =
             // TODO optimize this one with addMut
             { Widgets = x |> Seq.map(fun wb -> wb.Compile()) |> Seq.toArray |> MutStackArray1.fromArray }
 

--- a/src/Fabulous.Tests/ViewTests.fs
+++ b/src/Fabulous.Tests/ViewTests.fs
@@ -4,9 +4,7 @@ open Fabulous
 open Fabulous.StackAllocatedCollections.StackList
 open NUnit.Framework
 
-type ITestControl =
-    interface
-    end
+type ITestControl = interface end
 
 module TestControl =
     let WidgetKey: WidgetKey = 1

--- a/src/Fabulous/AttributeDefinitions.fs
+++ b/src/Fabulous/AttributeDefinitions.fs
@@ -31,10 +31,8 @@ module ScalarAttributeDefinitions =
               Value = null }
 
         static member inline CreateAttributeData<'T>
-            (
-                [<InlineIfLambda>] decode: uint64 -> 'T,
-                [<InlineIfLambda>] updateNode: 'T voption -> 'T voption -> IViewNode -> unit
-            ) : SmallScalarAttributeData =
+            ([<InlineIfLambda>] decode: uint64 -> 'T, [<InlineIfLambda>] updateNode: 'T voption -> 'T voption -> IViewNode -> unit)
+            : SmallScalarAttributeData =
             { UpdateNode =
                 (fun oldValueOpt newValueOpt node ->
                     let oldValueOpt =
@@ -64,10 +62,8 @@ module ScalarAttributeDefinitions =
               Value = value }
 
         static member CreateAttributeData
-            (
-                compare: 'T -> 'T -> ScalarAttributeComparison,
-                updateNode: 'T voption -> 'T voption -> IViewNode -> unit
-            ) : ScalarAttributeData =
+            (compare: 'T -> 'T -> ScalarAttributeComparison, updateNode: 'T voption -> 'T voption -> IViewNode -> unit)
+            : ScalarAttributeData =
             { CompareBoxed = (fun a b -> compare (unbox<'T> a) (unbox<'T> b))
               UpdateNode =
                 (fun oldValueOpt newValueOpt node ->

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -78,10 +78,8 @@ type SmallScalarExtensions() =
 
     [<Extension>]
     static member inline WithValue< ^T when ^T: enum<int> and ^T: (static member op_Explicit: ^T -> uint64)>
-        (
-            this: SmallScalarAttributeDefinition< ^T >,
-            value
-        ) =
+        (this: SmallScalarAttributeDefinition< ^T >, value)
+        =
         this.WithValue(value, SmallScalars.IntEnum.encode)
 
 type MsgValue = MsgValue of obj

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -10,7 +10,7 @@ open Microsoft.FSharp.Core
 type AttributesBundle = (struct (StackList<ScalarAttribute> * WidgetAttribute[] voption * WidgetCollectionAttribute[] voption))
 
 [<Struct; NoComparison; NoEquality>]
-type WidgetBuilder<'msg, 'marker when 'msg : equality> =
+type WidgetBuilder<'msg, 'marker when 'msg: equality> =
     struct
         val Key: WidgetKey
         val Attributes: AttributesBundle
@@ -122,7 +122,7 @@ type WidgetBuilder<'msg, 'marker when 'msg : equality> =
 type Content<'msg> = { Widgets: MutStackArray1.T<Widget> }
 
 [<Struct; NoComparison; NoEquality>]
-type CollectionBuilder<'msg, 'marker, 'itemMarker when 'msg : equality> =
+type CollectionBuilder<'msg, 'marker, 'itemMarker when 'msg: equality> =
     struct
         val WidgetKey: WidgetKey
         val Attr: WidgetCollectionAttributeDefinition
@@ -207,7 +207,7 @@ module CollectionBuilder =
         { Widgets = MutStackArray1.One(builder.Compile()) }
 
 [<Struct>]
-type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker when 'msg : equality> =
+type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker when 'msg: equality> =
     struct
         val Widget: WidgetBuilder<'msg, 'marker>
         val Attr: WidgetCollectionAttributeDefinition
@@ -240,10 +240,10 @@ type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker when 'msg : equality>
             res
     end
 
-type SingleChildBuilderStep<'msg, 'marker when 'msg : equality> = delegate of unit -> WidgetBuilder<'msg, 'marker>
+type SingleChildBuilderStep<'msg, 'marker when 'msg: equality> = delegate of unit -> WidgetBuilder<'msg, 'marker>
 
 [<Struct>]
-type SingleChildBuilder<'msg, 'marker, 'childMarker when 'msg : equality> =
+type SingleChildBuilder<'msg, 'marker, 'childMarker when 'msg: equality> =
     val WidgetKey: WidgetKey
     val Attr: WidgetAttributeDefinition
     val AttributesBundle: AttributesBundle
@@ -262,10 +262,8 @@ type SingleChildBuilder<'msg, 'marker, 'childMarker when 'msg : equality> =
         SingleChildBuilderStep(fun () -> widget)
 
     member inline this.Combine
-        (
-            [<InlineIfLambda>] a: SingleChildBuilderStep<'msg, 'childMarker>,
-            [<InlineIfLambda>] _b: SingleChildBuilderStep<'msg, 'childMarker>
-        ) =
+        ([<InlineIfLambda>] a: SingleChildBuilderStep<'msg, 'childMarker>, [<InlineIfLambda>] _b: SingleChildBuilderStep<'msg, 'childMarker>)
+        =
         SingleChildBuilderStep(fun () ->
             // We only want one child, so we ignore the second one
             a.Invoke())

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -10,7 +10,7 @@ open Microsoft.FSharp.Core
 type AttributesBundle = (struct (StackList<ScalarAttribute> * WidgetAttribute[] voption * WidgetCollectionAttribute[] voption))
 
 [<Struct; NoComparison; NoEquality>]
-type WidgetBuilder<'msg, 'marker> =
+type WidgetBuilder<'msg, 'marker when 'msg : equality> =
     struct
         val Key: WidgetKey
         val Attributes: AttributesBundle
@@ -122,7 +122,7 @@ type WidgetBuilder<'msg, 'marker> =
 type Content<'msg> = { Widgets: MutStackArray1.T<Widget> }
 
 [<Struct; NoComparison; NoEquality>]
-type CollectionBuilder<'msg, 'marker, 'itemMarker> =
+type CollectionBuilder<'msg, 'marker, 'itemMarker when 'msg : equality> =
     struct
         val WidgetKey: WidgetKey
         val Attr: WidgetCollectionAttributeDefinition
@@ -207,7 +207,7 @@ module CollectionBuilder =
         { Widgets = MutStackArray1.One(builder.Compile()) }
 
 [<Struct>]
-type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker> =
+type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker when 'msg : equality> =
     struct
         val Widget: WidgetBuilder<'msg, 'marker>
         val Attr: WidgetCollectionAttributeDefinition
@@ -240,10 +240,10 @@ type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker> =
             res
     end
 
-type SingleChildBuilderStep<'msg, 'marker> = delegate of unit -> WidgetBuilder<'msg, 'marker>
+type SingleChildBuilderStep<'msg, 'marker when 'msg : equality> = delegate of unit -> WidgetBuilder<'msg, 'marker>
 
 [<Struct>]
-type SingleChildBuilder<'msg, 'marker, 'childMarker> =
+type SingleChildBuilder<'msg, 'marker, 'childMarker when 'msg : equality> =
     val WidgetKey: WidgetKey
     val Attr: WidgetAttributeDefinition
     val AttributesBundle: AttributesBundle

--- a/src/Fabulous/Component.fs
+++ b/src/Fabulous/Component.fs
@@ -302,19 +302,22 @@ type Component(treeContext: ViewTreeContext, body: ComponentBody, context: Compo
         node
 
     member private this.RenderInternal() =
-        let prevRootWidget = _widget
-        let prevContext = _context
-        let struct (context, currRootWidget) = _body.Invoke(_context)
-        _widget <- currRootWidget
+        if _body = null then
+            () // Component has been disposed
+        else
+            let prevRootWidget = _widget
+            let prevContext = _context
+            let struct (context, currRootWidget) = _body.Invoke(_context)
+            _widget <- currRootWidget
 
-        if prevContext <> context then
-            _contextSubscription.Dispose()
-            _contextSubscription <- context.RenderNeeded.Subscribe(this.Render)
-            _context <- context
+            if prevContext <> context then
+                _contextSubscription.Dispose()
+                _contextSubscription <- context.RenderNeeded.Subscribe(this.Render)
+                _context <- context
 
-        let viewNode = treeContext.GetViewNode _view
+            let viewNode = treeContext.GetViewNode _view
 
-        Reconciler.update treeContext.CanReuseView (ValueSome prevRootWidget) currRootWidget viewNode
+            Reconciler.update treeContext.CanReuseView (ValueSome prevRootWidget) currRootWidget viewNode
 
     member this.Dispose() =
         if _contextSubscription <> null then

--- a/src/Fabulous/Component.fs
+++ b/src/Fabulous/Component.fs
@@ -394,7 +394,7 @@ module Component =
 /// It will be aggressively inlined by the compiler leaving no overhead, only a pure function that returns a WidgetBuilder
 type ComponentBodyBuilder<'marker> = delegate of bindings: int<binding> * context: ComponentContext -> struct (int<binding> * WidgetBuilder<unit, 'marker>)
 
-type ComponentBuilder<'parentMsg>() =
+type ComponentBuilder<'parentMsg when 'parentMsg : equality>() =
     member inline this.Yield(widgetBuilder: WidgetBuilder<unit, 'marker>) =
         ComponentBodyBuilder<'marker>(fun bindings ctx -> struct (bindings, widgetBuilder))
 

--- a/src/Fabulous/ComponentContext.fs
+++ b/src/Fabulous/ComponentContext.fs
@@ -86,6 +86,4 @@ type ComponentContext(initialSize: int) =
         member this.Dispose() = this.Dispose()
 
 [<AbstractClass; Sealed>]
-type Context private () =
-    class
-    end
+type Context private () = class end

--- a/src/Fabulous/MvuComponent.fs
+++ b/src/Fabulous/MvuComponent.fs
@@ -125,11 +125,11 @@ module MvuComponent =
 
 /// Delegate used by the MvuComponentBuilder to compose a component body
 /// It will be aggressively inlined by the compiler leaving no overhead, only a pure function that returns a WidgetBuilder
-type MvuComponentBodyBuilder<'msg, 'marker> =
+type MvuComponentBodyBuilder<'msg, 'marker when 'msg : equality> =
     delegate of bindings: int<binding> * context: ComponentContext -> struct (int<binding> * WidgetBuilder<'msg, 'marker>)
 
 [<Struct>]
-type MvuComponentBuilder<'arg, 'msg, 'model, 'marker, 'parentMsg> =
+type MvuComponentBuilder<'arg, 'msg, 'model, 'marker, 'parentMsg when 'msg : equality and 'parentMsg : equality> =
     val public Program: Program<obj, obj, obj>
     val public Arg: obj
 

--- a/src/Fabulous/MvuComponent.fs
+++ b/src/Fabulous/MvuComponent.fs
@@ -5,7 +5,8 @@ open System.Runtime.CompilerServices
 
 [<Struct; NoEquality; NoComparison>]
 type MvuComponentData =
-    { Body: ComponentBody
+    { Key: String
+      Body: ComponentBody
       Program: Program<obj, obj, obj>
       Arg: obj }
 
@@ -121,19 +122,21 @@ module MvuComponent =
             | _ -> failwith "Component widget must have a body"
 
         // NOTE: Somehow using = here crashes the app and prevents debugging...
-        Object.Equals(prevData.Arg, currData.Arg)
+        Object.Equals(prevData.Key, currData.Key)
+        && Object.Equals(prevData.Arg, currData.Arg)
 
 /// Delegate used by the MvuComponentBuilder to compose a component body
 /// It will be aggressively inlined by the compiler leaving no overhead, only a pure function that returns a WidgetBuilder
-type MvuComponentBodyBuilder<'msg, 'marker when 'msg : equality> =
+type MvuComponentBodyBuilder<'msg, 'marker when 'msg: equality> =
     delegate of bindings: int<binding> * context: ComponentContext -> struct (int<binding> * WidgetBuilder<'msg, 'marker>)
 
 [<Struct>]
-type MvuComponentBuilder<'arg, 'msg, 'model, 'marker, 'parentMsg when 'msg : equality and 'parentMsg : equality> =
+type MvuComponentBuilder<'arg, 'msg, 'model, 'marker, 'parentMsg when 'msg: equality and 'parentMsg: equality> =
+    val public Key: string
     val public Program: Program<obj, obj, obj>
     val public Arg: obj
 
-    new(program: Program<'arg, 'model, 'msg>, arg: 'arg) =
+    new(key: string, program: Program<'arg, 'model, 'msg>, arg: 'arg) =
         let program: Program<obj, obj, obj> =
             { Init = fun arg -> let model, cmd = program.Init(unbox arg) in (box model, Cmd.map box cmd)
               Update = fun (msg, model) -> let model, cmd = program.Update(unbox msg, unbox model) in (box model, Cmd.map box cmd)
@@ -141,7 +144,9 @@ type MvuComponentBuilder<'arg, 'msg, 'model, 'marker, 'parentMsg when 'msg : equ
               Logger = program.Logger
               ExceptionHandler = program.ExceptionHandler }
 
-        { Program = program; Arg = arg }
+        { Key = key
+          Program = program
+          Arg = arg }
 
     member inline this.Yield(widgetBuilder: WidgetBuilder<'msg, 'marker>) =
         MvuComponentBodyBuilder<'msg, 'marker>(fun bindings ctx -> struct (bindings, widgetBuilder))
@@ -168,15 +173,14 @@ type MvuComponentBuilder<'arg, 'msg, 'model, 'marker, 'parentMsg when 'msg : equ
                 struct (ctx, result.Compile()))
 
         let data =
-            { Program = this.Program
+            { Key = this.Key
+              Program = this.Program
               Arg = this.Arg
               Body = compiledBody }
 
         WidgetBuilder<'parentMsg, 'marker>(MvuComponent.WidgetKey, MvuComponent.Data.WithValue(data))
 
-type MvuStateRequest =
-    struct
-    end
+type MvuStateRequest = struct end
 
 type Mvu =
     static member inline State = MvuStateRequest()

--- a/src/Fabulous/Program.fs
+++ b/src/Fabulous/Program.fs
@@ -19,7 +19,7 @@ type Program<'arg, 'model, 'msg> =
         ExceptionHandler: exn -> bool
     }
 
-type Program<'arg, 'model, 'msg, 'marker> =
+type Program<'arg, 'model, 'msg, 'marker when 'msg : equality> =
     {
         State: Program<'arg, 'model, 'msg>
         /// Render the application state

--- a/src/Fabulous/Program.fs
+++ b/src/Fabulous/Program.fs
@@ -19,7 +19,7 @@ type Program<'arg, 'model, 'msg> =
         ExceptionHandler: exn -> bool
     }
 
-type Program<'arg, 'model, 'msg, 'marker when 'msg : equality> =
+type Program<'arg, 'model, 'msg, 'marker when 'msg: equality> =
     {
         State: Program<'arg, 'model, 'msg>
         /// Render the application state

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -15,7 +15,7 @@ module ViewHelpers =
 
 module View =
     /// Avoid recomputing the whole subtree when the key doesn't change
-    let lazy'<'msg, 'key, 'marker when 'key: equality> (fn: 'key -> WidgetBuilder<'msg, 'marker>) (key: 'key) : WidgetBuilder<'msg, Memo.Memoized<'marker>> =
+    let lazy'<'msg, 'key, 'marker when 'msg : equality and 'key: equality> (fn: 'key -> WidgetBuilder<'msg, 'marker>) (key: 'key) : WidgetBuilder<'msg, Memo.Memoized<'marker>> =
 
         let memo: Memo.MemoData =
             { KeyData = box key

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -8,6 +8,8 @@ module ViewHelpers =
             false
         else if (prevKey = Memo.MemoWidgetKey) then
             Memo.canReuseMemoizedWidget prevWidget currWidget
+        else if (prevKey = Component.WidgetKey) then
+            Component.canReuseComponent prevWidget currWidget
         else if (prevKey = MvuComponent.WidgetKey) then
             MvuComponent.canReuseMvuComponent prevWidget currWidget
         else
@@ -15,7 +17,10 @@ module ViewHelpers =
 
 module View =
     /// Avoid recomputing the whole subtree when the key doesn't change
-    let lazy'<'msg, 'key, 'marker when 'msg : equality and 'key: equality> (fn: 'key -> WidgetBuilder<'msg, 'marker>) (key: 'key) : WidgetBuilder<'msg, Memo.Memoized<'marker>> =
+    let lazy'<'msg, 'key, 'marker when 'msg: equality and 'key: equality>
+        (fn: 'key -> WidgetBuilder<'msg, 'marker>)
+        (key: 'key)
+        : WidgetBuilder<'msg, Memo.Memoized<'marker>> =
 
         let memo: Memo.MemoData =
             { KeyData = box key


### PR DESCRIPTION
This pull request adds an equality constraint on `'msg` on most types to prevent confusions with the new modifiers for non-MVU components.