### PR TITLE
Remove match struct

### DIFF
--- a/src/Fabulous/Array.fs
+++ b/src/Fabulous/Array.fs
@@ -49,7 +49,7 @@ module ArraySlice =
 module Array =
     let inline appendOne (v: 'v) (arr: 'v array) =
         let res = Array.zeroCreate(arr.Length + 1)
-        res[..arr.Length - 1] <- arr
+        res[.. arr.Length - 1] <- arr
         res[arr.Length] <- v
         res
 

--- a/src/Fabulous/Components/Component.fs
+++ b/src/Fabulous/Components/Component.fs
@@ -41,28 +41,28 @@ type Component
                     ValueSome(filteredAttrs) // skip the component data
 
             let scalars =
-                match struct (rootWidget.ScalarAttributes, componentScalars) with
+                match rootWidget.ScalarAttributes, componentScalars with
                 | ValueNone, ValueNone -> ValueNone
                 | ValueSome attrs, ValueNone
                 | ValueNone, ValueSome attrs -> ValueSome attrs
                 | ValueSome widgetAttrs, ValueSome componentAttrs -> ValueSome(Array.append componentAttrs widgetAttrs)
 
             let widgets =
-                match struct (rootWidget.WidgetAttributes, componentWidget.WidgetAttributes) with
+                match rootWidget.WidgetAttributes, componentWidget.WidgetAttributes with
                 | ValueNone, ValueNone -> ValueNone
                 | ValueSome attrs, ValueNone
                 | ValueNone, ValueSome attrs -> ValueSome attrs
                 | ValueSome widgetAttrs, ValueSome componentAttrs -> ValueSome(Array.append componentAttrs widgetAttrs)
 
             let widgetColls =
-                match struct (rootWidget.WidgetCollectionAttributes, componentWidget.WidgetCollectionAttributes) with
+                match rootWidget.WidgetCollectionAttributes, componentWidget.WidgetCollectionAttributes with
                 | ValueNone, ValueNone -> ValueNone
                 | ValueSome attrs, ValueNone
                 | ValueNone, ValueSome attrs -> ValueSome attrs
                 | ValueSome widgetAttrs, ValueSome componentAttrs -> ValueSome(Array.append componentAttrs widgetAttrs)
 
             let environments =
-                match struct (rootWidget.EnvironmentAttributes, componentWidget.EnvironmentAttributes) with
+                match rootWidget.EnvironmentAttributes, componentWidget.EnvironmentAttributes with
                 | ValueNone, ValueNone -> ValueNone
                 | ValueSome attrs, ValueNone
                 | ValueNone, ValueSome attrs -> ValueSome attrs

--- a/src/Fabulous/Components/ComponentContext.fs
+++ b/src/Fabulous/Components/ComponentContext.fs
@@ -48,7 +48,7 @@ type ComponentContext(initialSize: int) =
         if values.Length < count then
             let newLength = max (values.Length * 2) count
             let newArray = Array.zeroCreate newLength
-            newArray[..values.Length - 1] <- values
+            newArray[.. values.Length - 1] <- values
             values <- newArray
 
     member this.TryGetValue<'T>(key: int) =


### PR DESCRIPTION
[`match x, y with` doesn't create a tuple](https://sharplab.io/#v2:DYLgZgzgPsCmAuACAHognogXogvAWAChFjEBbAQ3gGMALdAGi0QHcBLeGwkxKRAbShQAuowHDEAWgB8iAIxcSvMSJSSZAJgXFeyUYKFrEAZi09EAfUMAWU4ThJkEdE3xESFanQjwATgFcqJAAKNEZMAEoWdk43bX59PXFpOVMlBNVkzVizXXikmRNs3ktkqyA===), so doing `match struct (x, y) with` actually adds extra overhead.