### PR TITLE
Optimize diffing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,10 @@
 <Project>
-  
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
-    <PackageVersion Include="FSharp.Core" Version="7.0.0" />
+    <PackageVersion Include="FSharp.Core" Version="9.0.101" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
@@ -15,5 +13,4 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
-
 </Project>

--- a/src/Fabulous.Benchmarks/Benchmarks.fs
+++ b/src/Fabulous.Benchmarks/Benchmarks.fs
@@ -183,7 +183,7 @@ let main _argv =
 
     printfn "Hello"
 
-    BenchmarkRunner.Run<DiffingSmallScalars.Benchmarks>() |> ignore
+    BenchmarkRunner.Run(typeof<DiffingSmallScalars.Benchmarks>.Assembly) |> ignore
 
     0 // return an integer exit code
 

--- a/src/Fabulous.Tests/Fabulous.Tests.fsproj
+++ b/src/Fabulous.Tests/Fabulous.Tests.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FsCheck.NUnit" />
+    <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/src/Fabulous/Logger.fs
+++ b/src/Fabulous/Logger.fs
@@ -3,7 +3,6 @@ namespace Fabulous
 open System
 open System.Runtime.CompilerServices
 
-[<Struct>]
 type LogLevel =
     | Debug = 0
     | Info = 1

--- a/src/Fabulous/Primitives.fs
+++ b/src/Fabulous/Primitives.fs
@@ -64,7 +64,7 @@ module ScalarAttributeKey =
         | Code.Inline -> Inline
         | _ -> Boxed
 
-    let inline getKeyValue (key: ScalarAttributeKey) : int = int((int key) &&& Code.KeyMask)
+    let inline getKeyValue (key: ScalarAttributeKey) : int = int key &&& Code.KeyMask
 
     let inline compare (a: ScalarAttributeKey) (b: ScalarAttributeKey) =
         let a = int a

--- a/src/Fabulous/Reconciler.fs
+++ b/src/Fabulous/Reconciler.fs
@@ -4,12 +4,8 @@ open Fabulous
 
 module Reconciler =
 
-    let private compareScalars (struct (key, a, b): struct (ScalarAttributeKey * obj * obj)) : ScalarAttributeComparison =
-        let data = AttributeDefinitionStore.getScalar key
-        data.CompareBoxed a b
-
     let update (canReuseView: Widget -> Widget -> bool) (prevOpt: Widget voption) (next: Widget) (node: IViewNode) : unit =
 
-        let diff = WidgetDiff.create(prevOpt, next, canReuseView, compareScalars)
+        let diff = WidgetDiff.create(prevOpt, next, canReuseView, fun key a b -> (AttributeDefinitionStore.getScalar key).CompareBoxed a b)
 
         node.ApplyDiff(&diff)

--- a/src/Fabulous/Reconciler.fs
+++ b/src/Fabulous/Reconciler.fs
@@ -6,6 +6,7 @@ module Reconciler =
 
     let update (canReuseView: Widget -> Widget -> bool) (prevOpt: Widget voption) (next: Widget) (node: IViewNode) : unit =
 
-        let diff = WidgetDiff.create(prevOpt, next, canReuseView, fun key a b -> (AttributeDefinitionStore.getScalar key).CompareBoxed a b)
+        let diff =
+            WidgetDiff.create(prevOpt, next, canReuseView, fun key a b -> (AttributeDefinitionStore.getScalar key).CompareBoxed a b)
 
         node.ApplyDiff(&diff)

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -92,7 +92,7 @@ type ViewNode =
 
                 definition.UpdateNode (ValueSome removed.Value) ValueNone (this :> IViewNode)
 
-            | WidgetChange.Updated (newAttr, diffs) ->
+            | WidgetChange.Updated(newAttr, diffs) ->
                 let definition = (AttributeDefinitionStore.getWidget newAttr.Key)
 
                 definition.ApplyDiff diffs (this :> IViewNode)
@@ -110,7 +110,7 @@ type ViewNode =
 
                 definition.UpdateNode (ValueSome removed.Value) ValueNone (this :> IViewNode)
 
-            | WidgetCollectionChange.Updated (oldAttr, newAttr, diffs) ->
+            | WidgetCollectionChange.Updated(oldAttr, newAttr, diffs) ->
                 let definition = (AttributeDefinitionStore.getWidgetCollection newAttr.Key)
 
                 definition.ApplyDiff oldAttr.Value diffs (this :> IViewNode)

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -92,7 +92,7 @@ type ViewNode =
 
                 definition.UpdateNode (ValueSome removed.Value) ValueNone (this :> IViewNode)
 
-            | WidgetChange.Updated struct (newAttr, diffs) ->
+            | WidgetChange.Updated (newAttr, diffs) ->
                 let definition = (AttributeDefinitionStore.getWidget newAttr.Key)
 
                 definition.ApplyDiff diffs (this :> IViewNode)
@@ -110,7 +110,7 @@ type ViewNode =
 
                 definition.UpdateNode (ValueSome removed.Value) ValueNone (this :> IViewNode)
 
-            | WidgetCollectionChange.Updated struct (oldAttr, newAttr, diffs) ->
+            | WidgetCollectionChange.Updated (oldAttr, newAttr, diffs) ->
                 let definition = (AttributeDefinitionStore.getWidgetCollection newAttr.Key)
 
                 definition.ApplyDiff oldAttr.Value diffs (this :> IViewNode)

--- a/src/Fabulous/WidgetDiff.fs
+++ b/src/Fabulous/WidgetDiff.fs
@@ -82,7 +82,7 @@ type ScalarChange =
 and [<Struct; RequireQualifiedAccess>] WidgetChange =
     | Added of widget: WidgetAttribute
     | Removed of widget: WidgetAttribute
-    | Updated of widget: WidgetAttribute * diff: WidgetDiff // old * diff
+    | Updated of widget: WidgetAttribute * diff: WidgetDiff // updated * diff
     | ReplacedBy of widget: WidgetAttribute
 
 and [<Struct; RequireQualifiedAccess>] WidgetCollectionChange =

--- a/src/Fabulous/WidgetDiff.fs
+++ b/src/Fabulous/WidgetDiff.fs
@@ -11,9 +11,9 @@ type ScalarAttributeComparison =
 
 [<Struct; IsByRefLike; RequireQualifiedAccess; NoComparison; NoEquality>]
 type EnumerationMode<'a> =
-    | AllAddedOrRemoved of prevAdd: 'a[] * bool // the first element is either prev or next depending on the bool, but using prev as the label allows the compiler to reuse struct fields between cases
+    | AllAddedOrRemoved of prev: 'a[] * bool // the first element is either prev or next depending on the bool, but using prev as the label allows the compiler to reuse struct fields between cases
     | Empty
-    | ActualDiff of prevDiff: 'a[] * next: 'a[]
+    | ActualDiff of prev: 'a[] * next: 'a[]
 
 module EnumerationMode =
     let fromOptions prev next =
@@ -75,31 +75,31 @@ module private SkipRepeatingScalars =
 
 [<Struct; IsByRefLike; RequireQualifiedAccess>]
 type ScalarChange =
-    | Added of added: ScalarAttribute
-    | Removed of removed: ScalarAttribute
-    | Updated of old: ScalarAttribute * updated: ScalarAttribute
+    | Added of attr: ScalarAttribute
+    | Removed of attr: ScalarAttribute
+    | Updated of attr: ScalarAttribute * updated: ScalarAttribute // old * updated
 
 and [<Struct; RequireQualifiedAccess>] WidgetChange =
-    | Added of added: WidgetAttribute
-    | Removed of removed: WidgetAttribute
-    | Updated of updated: struct (WidgetAttribute * WidgetDiff)
-    | ReplacedBy of replacedBy: WidgetAttribute
+    | Added of widget: WidgetAttribute
+    | Removed of widget: WidgetAttribute
+    | Updated of widget: WidgetAttribute * diff: WidgetDiff // old * diff
+    | ReplacedBy of widget: WidgetAttribute
 
 and [<Struct; RequireQualifiedAccess>] WidgetCollectionChange =
-    | Added of added: WidgetCollectionAttribute
-    | Removed of removed: WidgetCollectionAttribute
-    | Updated of updated: struct (WidgetCollectionAttribute * WidgetCollectionAttribute * WidgetCollectionItemChanges)
+    | Added of attr: WidgetCollectionAttribute
+    | Removed of attr: WidgetCollectionAttribute
+    | Updated of attr: WidgetCollectionAttribute * updated: WidgetCollectionAttribute * diff: WidgetCollectionItemChanges // old * updated * diff
 
 and [<Struct; IsByRefLike; RequireQualifiedAccess>] WidgetCollectionItemChange =
-    | Insert of widgetInserted: struct (int * Widget)
-    | Replace of widgetReplaced: struct (int * Widget * Widget)
-    | Update of widgetUpdated: struct (int * WidgetDiff)
-    | Remove of removed: struct (int * Widget)
+    | Insert of index: int * widget: Widget
+    | Replace of index: int * widget: Widget * replacedBy: Widget // index * old * replacedBy
+    | Update of index: int * diff: WidgetDiff
+    | Remove of index: int * widget: Widget
 
 and [<Struct; IsByRefLike; RequireQualifiedAccess>] EnvironmentChange =
-    | Added of added: EnvironmentAttribute
-    | Removed of removed: EnvironmentAttribute
-    | Updated of old: EnvironmentAttribute * updated: EnvironmentAttribute
+    | Added of attr: EnvironmentAttribute
+    | Removed of attr: EnvironmentAttribute
+    | Updated of attr: EnvironmentAttribute * updated: EnvironmentAttribute // old * updated
 
 and [<Struct; NoComparison; NoEquality>] WidgetDiff =
     { ScalarChanges: ScalarChanges
@@ -112,7 +112,7 @@ and [<Struct; NoComparison; NoEquality>] WidgetDiff =
             prevOpt: Widget voption,
             next: Widget,
             canReuseView: Widget -> Widget -> bool,
-            compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison
+            compareScalars: ScalarAttributeKey -> obj -> obj -> ScalarAttributeComparison
         ) : WidgetDiff =
 
         let prevScalarAttributes =
@@ -141,7 +141,7 @@ and [<Struct; NoComparison; NoEquality>] WidgetDiff =
           EnvironmentChanges = EnvironmentChanges(prevEnvironmentAttributes, next.EnvironmentAttributes) }
 
 and [<Struct; NoComparison; NoEquality>] ScalarChanges
-    (prev: ScalarAttribute[], next: ScalarAttribute[], compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison) =
+    (prev: ScalarAttribute[], next: ScalarAttribute[], compareScalars: ScalarAttributeKey -> obj -> obj -> ScalarAttributeComparison) =
     member _.GetEnumerator() =
         ScalarChangesEnumerator(EnumerationMode.fromOptions prev next, compareScalars)
 
@@ -150,7 +150,7 @@ and [<Struct; NoComparison; NoEquality>] WidgetChanges
         prev: WidgetAttribute[],
         next: WidgetAttribute[],
         canReuseView: Widget -> Widget -> bool,
-        compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison
+        compareScalars: ScalarAttributeKey -> obj -> obj -> ScalarAttributeComparison
     ) =
     member _.GetEnumerator() =
         WidgetChangesEnumerator(EnumerationMode.fromOptions prev next, canReuseView, compareScalars)
@@ -160,7 +160,7 @@ and [<Struct; NoComparison; NoEquality>] WidgetCollectionChanges
         prev: WidgetCollectionAttribute[],
         next: WidgetCollectionAttribute[],
         canReuseView: Widget -> Widget -> bool,
-        compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison
+        compareScalars: ScalarAttributeKey -> obj -> obj -> ScalarAttributeComparison
     ) =
     member _.GetEnumerator() =
         WidgetCollectionChangesEnumerator(EnumerationMode.fromOptions prev next, canReuseView, compareScalars)
@@ -171,7 +171,7 @@ and [<Struct; NoComparison; NoEquality>] WidgetCollectionItemChanges
         prev: ArraySlice<Widget>,
         next: ArraySlice<Widget>,
         canReuseView: Widget -> Widget -> bool,
-        compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison
+        compareScalars: ScalarAttributeKey -> obj -> obj -> ScalarAttributeComparison
     ) =
     member _.GetEnumerator() =
         WidgetCollectionItemChangesEnumerator(ArraySlice.toSpan prev, ArraySlice.toSpan next, canReuseView, compareScalars)
@@ -182,7 +182,7 @@ and [<Struct; NoComparison; NoEquality>] EnvironmentChanges(prev: EnvironmentAtt
 
 // enumerators
 and [<Struct; IsByRefLike>] ScalarChangesEnumerator
-    (mode: EnumerationMode<ScalarAttribute>, compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison) =
+    (mode: EnumerationMode<ScalarAttribute>, compareScalars: ScalarAttributeKey -> obj -> obj -> ScalarAttributeComparison) =
 
     [<DefaultValue(false)>]
     val mutable private current: ScalarChange
@@ -270,7 +270,7 @@ and [<Struct; IsByRefLike>] ScalarChangesEnumerator
                                     res <- ValueSome true
 
                             | ScalarAttributeKey.Kind.Boxed ->
-                                match compareScalars struct (prevKey, prevAttr.Value, nextAttr.Value) with
+                                match compareScalars prevKey prevAttr.Value nextAttr.Value with
                                 // Previous and next values are identical, we don't need to do anything
                                 | ScalarAttributeComparison.Identical -> ()
 
@@ -297,7 +297,7 @@ and [<Struct; IsByRefLike>] WidgetChangesEnumerator
     (
         mode: EnumerationMode<WidgetAttribute>,
         canReuseView: Widget -> Widget -> bool,
-        compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison
+        compareScalars: ScalarAttributeKey -> obj -> obj -> ScalarAttributeComparison
     ) =
 
     [<DefaultValue(false)>]
@@ -414,7 +414,7 @@ and [<Struct; IsByRefLike>] WidgetCollectionChangesEnumerator
     (
         mode: EnumerationMode<WidgetCollectionAttribute>,
         canReuseView: Widget -> Widget -> bool,
-        compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison
+        compareScalars: ScalarAttributeKey -> obj -> obj -> ScalarAttributeComparison
     ) =
 
     [<DefaultValue(false)>]
@@ -515,7 +515,7 @@ and [<Struct; IsByRefLike>] WidgetCollectionItemChangesEnumerator
         prev: Span<Widget>,
         next: Span<Widget>,
         canReuseView: Widget -> Widget -> bool,
-        compareScalars: struct (ScalarAttributeKey * obj * obj) -> ScalarAttributeComparison
+        compareScalars: ScalarAttributeKey -> obj -> obj -> ScalarAttributeComparison
     ) =
     [<DefaultValue(false)>]
     val mutable private current: WidgetCollectionItemChange


### PR DESCRIPTION
Taking advantage of the fact that the compiler can deduplicate struct DU case fields with the same name and type.

Before

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.2894)
AMD Ryzen 9 7900, 1 CPU, 24 logical and 12 physical cores
.NET SDK 9.0.200-preview.0.24575.35
  [Host]     : .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI DEBUG
  DefaultJob : .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
```

| Method            | depth | boxed | Mean     | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|------------------ |------ |------ |---------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| **ProcessIncrements** | **15**    | **False** | **464.0 ms** |  **7.97 ms** |  **9.18 ms** | **14000.0000** | **11000.0000** | **1000.0000** | **215.61 MB** |
| **ProcessIncrements** | **15**    | **True**  | **598.1 ms** | **11.63 ms** | **12.45 ms** | **18000.0000** | **16000.0000** | **1000.0000** | **282.03 MB** |

| Method          | depth | Mean      | Error     | StdDev    | Gen0       | Gen1       | Gen2      | Allocated |
|---------------- |------ |----------:|----------:|----------:|-----------:|-----------:|----------:|----------:|
| **ProcessMessages** | **10**    |  **64.84 ms** |  **0.981 ms** |  **0.917 ms** |  **3250.0000** |   **500.0000** |  **375.0000** |   **53.4 MB** |
| **ProcessMessages** | **15**    | **979.75 ms** | **19.593 ms** | **18.327 ms** | **38000.0000** | **36000.0000** | **1000.0000** | **594.07 MB** |
| **CreateWidgets** | **10**    |    **180.9 μs** |     **2.07 μs** |     **1.83 μs** |   **27.3438** |   **22.2168** |        **-** |  **448.23 KB** |
| **CreateWidgets** | **20**    | **67,747.6 μs** | **1,327.79 μs** | **1,861.37 μs** | **4125.0000** | **4000.0000** | **750.0000** | **55342.1 KB** |

After

| Method            | depth | boxed | Mean     | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|------------------ |------ |------ |---------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| **ProcessIncrements** | **15**    | **False** | **350.1 ms** |  **4.86 ms** |  **4.31 ms** | **14000.0000** | **11000.0000** | **1000.0000** | **215.61 MB** |
| **ProcessIncrements** | **15**    | **True**  | **516.6 ms** | **10.31 ms** | **15.43 ms** | **18000.0000** | **16000.0000** | **1000.0000** | **282.03 MB** |


| Method        | depth | Mean        | Error       | StdDev      | Gen0      | Gen1      | Gen2     | Allocated   |
|-------------- |------ |------------:|------------:|------------:|----------:|----------:|---------:|------------:|
| **ProcessMessages** | **10**    |  **56.67 ms** |  **0.833 ms** |  **0.779 ms** |  **3300.0000** |   **500.0000** |  **400.0000** |   **53.4 MB** |
| **ProcessMessages** | **15**    | **891.50 ms** | **17.655 ms** | **20.332 ms** | **38000.0000** | **36000.0000** | **1000.0000** | **594.07 MB** |
| **CreateWidgets** | **10**    |    **178.3 μs** |     **1.42 μs** |     **1.11 μs** |   **27.3438** |   **22.2168** |        **-** |   **448.23 KB** |
| **CreateWidgets** | **20**    | **68,374.6 μs** | **1,348.72 μs** | **2,099.80 μs** | **4125.0000** | **4000.0000** | **750.0000** | **55342.09 KB** |