### PR TITLE
target net8 to fix attribute targets incompatibilities.

### DIFF
--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -1,7 +1,6 @@
 namespace Fabulous
 
 open System.ComponentModel
-open Fabulous.WidgetAttributeDefinitions
 open Fabulous.WidgetCollectionAttributeDefinitions
 open Fabulous.StackAllocatedCollections
 open Fabulous.StackAllocatedCollections.StackList

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
     <PackageId>Fabulous</PackageId>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
@@ -60,6 +60,6 @@
       FSharp.Core is fixed to a specific version that is not necessarily the latest one.
       This version will be used as the lower bound in the NuGet package
     -->
-    <PackageReference Include="FSharp.Core" VersionOverride="7.0.0" />
+    <PackageReference Include="FSharp.Core" VersionOverride="8.0.300" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In NET 9 the F# compiler has a better analysis  for `AttributeTargets` but this means that we will need to use NET 8 minimum and FSharp.Core `8.0.300` to be able to build with NET 9 installed.
