### PR TITLE
Update Fabulous.MauiControls to MAUI 10

### DIFF
--- a/src/maui/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/maui/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -156,8 +156,8 @@
     -->
     <PackageReference Include="FSharp.Core" VersionOverride="8.0.300" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="8.0.3" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="8.0.3" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\neutral\Fabulous.Core\Fabulous.Core.fsproj" />

--- a/src/maui/Fabulous.MauiControls/Views/Controls/DatePicker.fs
+++ b/src/maui/Fabulous.MauiControls/Views/Controls/DatePicker.fs
@@ -58,8 +58,9 @@ module DatePicker =
                         // Set the new event handler
                         let handler =
                             target.DateSelected.Subscribe(fun args ->
-                                let (MsgValue r) = curr.Event args
-                                Dispatcher.dispatch node r)
+                                if args.NewDate.HasValue then
+                                    let (MsgValue r) = curr.Event args
+                                    Dispatcher.dispatch node r)
 
                         node.SetHandler(name, handler))
             )
@@ -108,7 +109,7 @@ module DatePickerBuilders =
             WidgetBuilder<'msg, IFabDatePicker>(
                 DatePicker.WidgetKey,
                 DatePicker.DateWithEvent.WithValue(
-                    ValueEventData.create (struct (min, max, date)) (fun (args: DateChangedEventArgs) -> onDateSelected args.NewDate)
+                    ValueEventData.create (struct (min, max, date)) (fun (args: DateChangedEventArgs) -> onDateSelected args.NewDate.Value)
                 )
             )
 

--- a/src/maui/Fabulous.MauiControls/Views/Controls/TimePicker.fs
+++ b/src/maui/Fabulous.MauiControls/Views/Controls/TimePicker.fs
@@ -26,8 +26,8 @@ type FabTimePicker() =
     override this.OnPropertyChanged(propertyName) =
         base.OnPropertyChanged(propertyName)
 
-        if propertyName = TimePicker.TimeProperty.PropertyName then
-            timeSelected.Trigger(this, TimeSelectedEventArgs(this.Time))
+        if propertyName = TimePicker.TimeProperty.PropertyName && this.Time.HasValue then
+            timeSelected.Trigger(this, TimeSelectedEventArgs(this.Time.Value))
 
 module TimePicker =
     let WidgetKey = Widgets.register<FabTimePicker>()


### PR DESCRIPTION
Update the core Fabulous.MauiControls package to consume the centrally managed latest stable .NET MAUI packages (10.0.100) instead of overriding them with 8.0.3.

Adapt the DatePicker and TimePicker event bridges to MAUI 10's nullable picker values while preserving the existing non-nullable Fabulous API. Null/cleared values do not dispatch selection messages.

Validation:
- `dotnet test Fabulous.sln -c Release --no-restore` (45 passed)
- Fabulous.MauiControls build and pack
- Fabulous.MauiControls.Maps build
- Fabulous.MauiControls.MediaElement build
- Packed dependencies resolve to Microsoft.Maui.Controls 10.0.100 and Microsoft.Maui.Controls.Compatibility 10.0.100
- Repository inventory and workflow lint