### PR TITLE
Cancel superseded workflows and cache NuGet packages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -244,6 +244,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/*.proj', '**/*.props', '**/*.targets', '**/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ github.job }}-
+            nuget-${{ runner.os }}-
       - name: Select installed .NET 10 SDK
         run: |
           sdk_version=$(dotnet --list-sdks | awk '/^10\.0\./ { version=$1 } END { print version }')
@@ -281,6 +289,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/*.proj', '**/*.props', '**/*.targets', '**/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ github.job }}-
+            nuget-${{ runner.os }}-
       - name: Select .NET 10 SDK
         run: |
           $sdkVersion = dotnet --list-sdks |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CONFIG: Release
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   CONFIG: Release
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
 jobs:
   validate:
@@ -27,6 +28,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/*.proj', '**/*.props', '**/*.targets', '**/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ github.job }}-
+            nuget-${{ runner.os }}-
       - name: Validate monorepo migration inventory
         run: python3 eng/monorepo/validate-inventory.py
       - name: Check core code formatting
@@ -46,6 +55,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/*.proj', '**/*.props', '**/*.targets', '**/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ github.job }}-
+            nuget-${{ runner.os }}-
       - name: Install MAUI workload packs
         run: dotnet workload install maui-tizen --skip-manifest-update
       - name: Test
@@ -87,6 +104,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/*.proj', '**/*.props', '**/*.targets', '**/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ github.job }}-
+            nuget-${{ runner.os }}-
       - name: Test view logic
         run: dotnet test samples/avalonia/TestableApp.UnitTests/TestableApp.UnitTests.fsproj -c ${CONFIG} -p:FabulousSamplesDesktopOnly=true
       - name: Test headless UI
@@ -133,6 +158,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/*.proj', '**/*.props', '**/*.targets', '**/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ github.job }}-
+            nuget-${{ runner.os }}-
       - name: Download packages
         uses: actions/download-artifact@v4
         with:
@@ -162,6 +195,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/*.proj', '**/*.props', '**/*.targets', '**/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ github.job }}-
+            nuget-${{ runner.os }}-
       - name: Select installed .NET 10 SDK
         run: |
           sdk_version=$(dotnet --list-sdks | awk '/^10\.0\./ { version=$1 } END { print version }')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
 env:
   CONFIG: Release
   SLN_FILE: Fabulous.sln
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
 jobs:
   detect:
@@ -71,6 +72,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/*.proj', '**/*.props', '**/*.targets', '**/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ github.job }}-
+            nuget-${{ runner.os }}-
       - name: Install MAUI workload packs
         run: dotnet workload install maui-tizen --skip-manifest-update
       - name: Restore


### PR DESCRIPTION
## Summary

- cancel superseded Build and test runs per pull request or branch
- cancel superseded GitHub Pages runs
- cache workspace-local NuGet packages with manifest-sensitive, per-job keys and cross-job fallback
- reuse the NuGet cache during release builds

## Observed results

Cancellation was exercised twice while building this PR. Superseded runs `32720432540` and `32720488035` were cancelled after **52s** and **5m52s** respectively. Their incomplete jobs had consumed about **11m10s** of runner time when cancellation took effect; allowing those jobs to finish would have consumed more.

For the 7 successful runs among the 8 most recent `main` pushes before this PR, median wall time was **5m09s**. Those older successful runs predate the current Android and Apple runtime jobs, so they are not directly comparable to the current workflow. The latest current-shape `main` run (`32716970169`) took **12m09s** and failed in the Android launch assertion.

The first complete PR run (`32720969143`, attempt 1) succeeded in **9m31s** with exact NuGet cache hits on all Linux jobs and cold caches on Apple and Windows. A same-SHA fully warm rerun succeeded in **8m25s**, **1m06s / 11.6% faster**. Apple remained the critical path at **8m25s**; Windows took **4m42s**, versus **4m49s** with a cold Windows cache. This indicates the cache is working, while platform workload installation/build time remains the dominant cost.

Compared with the latest current-shape `main` run, the successful warm PR run was **3m44s / 30.7% shorter**, with the caveat that the `main` run failed before completing every job.

## Validation

- `actionlint .github/workflows/*.yml`
- `python3 -B eng/monorepo/validate-inventory.py`
- complete CI run: success
- fully warm same-SHA CI rerun: success
