### PR TITLE
Speed up sample runtime validation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -118,10 +118,59 @@ jobs:
         run: dotnet run --project samples/avalonia/TestableApp.Headless.XUnit/TestableApp.Headless.XUnit.fsproj -c ${CONFIG} -p:FabulousSamplesDesktopOnly=true
         env:
           FABULOUS_SCREENSHOT_DIR: ${{ github.workspace }}/artifacts/screenshots/avalonia-headless
+      - name: Upload headless screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: Avalonia-Headless-Screenshots
+          path: artifacts/screenshots/avalonia-headless/
+          if-no-files-found: error
+
+  avalonia-capture:
+    name: Avalonia capture shard ${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/*.proj', '**/*.props', '**/*.targets', '**/dotnet-tools.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ github.job }}-
+            nuget-${{ runner.os }}-
       - name: Install desktop capture tools
         run: sudo apt-get update && sudo apt-get install -y imagemagick xdotool xvfb
-      - name: Build, run, and capture every sample
-        run: xvfb-run --auto-servernum --server-args='-screen 0 1440x900x24' bash eng/ci/capture-avalonia-samples.sh
+      - name: Build, run, and capture sample shard
+        run: xvfb-run --auto-servernum --server-args='-screen 0 1440x900x24' bash eng/ci/capture-avalonia-samples.sh ${{ matrix.shard }} 4
+        env:
+          CONFIG: Debug
+      - name: Upload shard screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: Avalonia-Screenshots-${{ matrix.shard }}
+          path: artifacts/screenshots/avalonia/
+          if-no-files-found: error
+
+  avalonia-screenshots:
+    name: Aggregate Avalonia screenshots
+    needs: [avalonia-samples, avalonia-capture]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download screenshots
+        uses: actions/download-artifact@v4
+        with:
+          pattern: Avalonia-*Screenshots*
+          path: artifacts/screenshots/
+          merge-multiple: true
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
         with:
@@ -152,6 +201,8 @@ jobs:
         run: dotnet workload install maui-android --skip-manifest-update
       - name: Build Android sample shard
         run: bash eng/ci/capture-maui-android-samples.sh build ${{ matrix.shard }} 4
+        env:
+          CONFIG: Debug
       - name: Upload signed Android packages
         uses: actions/upload-artifact@v4
         with:

--- a/eng/ci/capture-avalonia-samples.sh
+++ b/eng/ci/capture-avalonia-samples.sh
@@ -45,11 +45,15 @@ for project_index in "${!projects[@]}"; do
   if [[ "$is_gallery" == true ]]; then
     mapfile -t gallery_pages < <(python3 - <<'PY'
 import re
+import sys
 from pathlib import Path
 
 source = Path("samples/avalonia/Gallery/MainView.fs").read_text()
 registry = source.split("let controlNames =", 1)[1].split("let program =", 1)[0]
 for name in dict.fromkeys(re.findall(r'"([^"]+)"', registry)):
+  if name == "TreeDataGrid":
+    print("Skipping TreeDataGrid because Avalonia 12 requires a license key.", file=sys.stderr)
+  else:
     print(name)
 PY
 )
@@ -115,8 +119,11 @@ PY
 
       xdotool windowactivate --sync "$window_id" 2>/dev/null || true
       if import -window "$window_id" "$screenshot" 2>>"$log"; then
-        captured=true
-        break
+        colors=$(identify -format '%k' "$screenshot")
+        if [[ "$colors" -ge 2 ]]; then
+          captured=true
+          break
+        fi
       fi
 
       rm -f "$screenshot"
@@ -126,12 +133,6 @@ PY
     if [[ "$captured" != true ]]; then
       cat "$log"
       echo "$relative did not expose a stable window for $page." >&2
-      exit 1
-    fi
-
-    colors=$(identify -format '%k' "$screenshot")
-    if [[ "$colors" -lt 2 ]]; then
-      echo "$relative $page produced a blank screenshot." >&2
       exit 1
     fi
 

--- a/eng/ci/capture-avalonia-samples.sh
+++ b/eng/ci/capture-avalonia-samples.sh
@@ -38,23 +38,20 @@ for project_index in "${!projects[@]}"; do
   slug="${slug// /-}"
 
   echo "::group::Build $relative"
-  dotnet build "$project" -c "$configuration" -p:FabulousSamplesDesktopOnly=true
+  dotnet build "$project" -c "$configuration" -p:FabulousSamplesDesktopOnly=true \
+    -p:FabulousIncludePremiumControls=false
   echo "::endgroup::"
 
   pages=("")
   if [[ "$is_gallery" == true ]]; then
     mapfile -t gallery_pages < <(python3 - <<'PY'
 import re
-import sys
 from pathlib import Path
 
 source = Path("samples/avalonia/Gallery/MainView.fs").read_text()
-registry = source.split("let controlNames =", 1)[1].split("let program =", 1)[0]
+registry = source.split("let freeControlNames =", 1)[1].split("#if PREMIUM_CONTROLS", 1)[0]
 for name in dict.fromkeys(re.findall(r'"([^"]+)"', registry)):
-  if name == "TreeDataGrid":
-    print("Skipping TreeDataGrid because Avalonia 12 requires a license key.", file=sys.stderr)
-  else:
-    print(name)
+  print(name)
 PY
 )
     pages+=("${gallery_pages[@]}")
@@ -74,7 +71,8 @@ PY
 
     mapfile -t existing_windows < <(xdotool search --onlyvisible --name '.*' 2>/dev/null || true)
     FABULOUS_GALLERY_PAGE="$page" dotnet run --project "$project" -c "$configuration" -f net10.0 \
-      -p:FabulousSamplesDesktopOnly=true --no-build --no-restore >"$log" 2>&1 &
+      -p:FabulousSamplesDesktopOnly=true -p:FabulousIncludePremiumControls=false \
+      --no-build --no-restore >"$log" 2>&1 &
     app_pid=$!
 
     window_id=""

--- a/eng/ci/capture-avalonia-samples.sh
+++ b/eng/ci/capture-avalonia-samples.sh
@@ -3,7 +3,14 @@ set -euo pipefail
 
 configuration="${CONFIG:-Release}"
 output_dir="${FABULOUS_SCREENSHOT_DIR:-$PWD/artifacts/screenshots/avalonia}"
+shard_index="${1:-0}"
+shard_count="${2:-1}"
 mkdir -p "$output_dir"
+
+if ((shard_index < 0 || shard_index >= shard_count)); then
+  echo "Invalid shard $shard_index of $shard_count." >&2
+  exit 2
+fi
 
 mapfile -d '' projects < <(
   find samples/avalonia -name '*.fsproj' \
@@ -13,10 +20,19 @@ mapfile -d '' projects < <(
 )
 
 test "${#projects[@]}" -gt 0
-printf 'Capturing %d Avalonia sample applications.\n' "${#projects[@]}"
+printf 'Capturing Avalonia sample shard %d of %d.\n' "$shard_index" "$shard_count"
 
-for project in "${projects[@]}"; do
+captured_projects=0
+for project_index in "${!projects[@]}"; do
+  project="${projects[$project_index]}"
   relative="${project#samples/avalonia/}"
+  is_gallery=false
+  if [[ "$relative" == "Gallery/Gallery.fsproj" ]]; then
+    is_gallery=true
+  elif ((project_index % shard_count != shard_index)); then
+    continue
+  fi
+
   slug="${relative%.fsproj}"
   slug="${slug//\//-}"
   slug="${slug// /-}"
@@ -26,7 +42,7 @@ for project in "${projects[@]}"; do
   echo "::endgroup::"
 
   pages=("")
-  if [[ "$relative" == "Gallery/Gallery.fsproj" ]]; then
+  if [[ "$is_gallery" == true ]]; then
     mapfile -t gallery_pages < <(python3 - <<'PY'
 import re
 from pathlib import Path
@@ -40,7 +56,12 @@ PY
     pages+=("${gallery_pages[@]}")
   fi
 
-  for page in "${pages[@]}"; do
+  for page_index in "${!pages[@]}"; do
+    if [[ "$is_gallery" == true ]] && ((page_index % shard_count != shard_index)); then
+      continue
+    fi
+
+    page="${pages[$page_index]}"
     page_slug="${page// /-}"
     page_slug="${page_slug//\//-}"
     capture_slug="$slug${page_slug:+-$page_slug}"
@@ -49,7 +70,7 @@ PY
 
     mapfile -t existing_windows < <(xdotool search --onlyvisible --name '.*' 2>/dev/null || true)
     FABULOUS_GALLERY_PAGE="$page" dotnet run --project "$project" -c "$configuration" -f net10.0 \
-      -p:FabulousSamplesDesktopOnly=true --no-build >"$log" 2>&1 &
+      -p:FabulousSamplesDesktopOnly=true --no-build --no-restore >"$log" 2>&1 &
     app_pid=$!
 
     window_id=""
@@ -76,9 +97,37 @@ PY
       exit 1
     fi
 
-    xdotool windowactivate --sync "$window_id" 2>/dev/null || true
-    sleep 2
-    import -window "$window_id" "$screenshot"
+    captured=false
+    for _ in {1..10}; do
+      if ! kill -0 "$app_pid" 2>/dev/null; then
+        cat "$log"
+        echo "$relative exited before $page could be captured." >&2
+        exit 1
+      fi
+
+      mapfile -t visible_windows < <(xdotool search --onlyvisible --name '.*' 2>/dev/null || true)
+      for candidate in "${visible_windows[@]}"; do
+        if [[ ! " ${existing_windows[*]} " =~ " $candidate " ]]; then
+          window_id="$candidate"
+          break
+        fi
+      done
+
+      xdotool windowactivate --sync "$window_id" 2>/dev/null || true
+      if import -window "$window_id" "$screenshot" 2>>"$log"; then
+        captured=true
+        break
+      fi
+
+      rm -f "$screenshot"
+      sleep 1
+    done
+
+    if [[ "$captured" != true ]]; then
+      cat "$log"
+      echo "$relative did not expose a stable window for $page." >&2
+      exit 1
+    fi
 
     colors=$(identify -format '%k' "$screenshot")
     if [[ "$colors" -lt 2 ]]; then
@@ -90,6 +139,8 @@ PY
     wait "$app_pid" 2>/dev/null || true
     printf 'Captured %s (%s colors).\n' "$screenshot" "$colors"
   done
+  captured_projects=$((captured_projects + 1))
 done
 
-printf 'Captured %d Avalonia sample screenshots.\n' "${#projects[@]}"
+test "$captured_projects" -gt 0
+printf 'Captured %d Avalonia sample applications.\n' "$captured_projects"

--- a/eng/ci/capture-maui-android-samples.sh
+++ b/eng/ci/capture-maui-android-samples.sh
@@ -130,6 +130,7 @@ build_samples() {
     echo "::group::Build $relative"
     dotnet build "$project" -t:SignAndroidPackage -c "$configuration" -f net10.0-android -r android-x64 \
       -p:FabulousAndroidOnly=true \
+      -p:EmbedAssembliesIntoApk=true \
       -p:AndroidPackageFormat=apk -p:AndroidPackageFormats=apk
     echo "::endgroup::"
 

--- a/samples/avalonia/Gallery/App.Premium.xaml
+++ b/samples/avalonia/Gallery/App.Premium.xaml
@@ -1,0 +1,51 @@
+<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:gallery="clr-namespace:Gallery">
+    <StyleInclude Source="avares://Gallery/App.xaml" />
+    <StyleInclude Source="avares://Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml" />
+    <Styles.Resources>
+        <DataTemplate x:Key="RegionCell" DataType="gallery:Country">
+            <TextBlock Text="{Binding Region}" />
+        </DataTemplate>
+        <DataTemplate x:Key="RegionEditCell" DataType="gallery:Country">
+            <ComboBox ItemsSource="{x:Static gallery:Countries.Regions}"
+                      SelectedItem="{Binding Region}" />
+        </DataTemplate>
+        <DataTemplate x:Key="FileNameCell" DataType="gallery:FileTreeNodeModel">
+            <StackPanel Orientation="Horizontal">
+                <Image Margin="0 0 4 0" VerticalAlignment="Center">
+                    <Image.Source>
+                        <MultiBinding Converter="{x:Static gallery:FileTreeNodeModel.FileIconConverter}">
+                            <Binding Path="IsDirectory" />
+                            <Binding Path="IsExpanded" />
+                        </MultiBinding>
+                    </Image.Source>
+                </Image>
+                <TextBlock Text="{Binding Name}" VerticalAlignment="Center" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate x:Key="FileNameEditCell" DataType="gallery:FileTreeNodeModel">
+            <StackPanel Orientation="Horizontal">
+                <Image Margin="0 0 4 0" VerticalAlignment="Center">
+                    <Image.Source>
+                        <MultiBinding Converter="{x:Static gallery:FileTreeNodeModel.FileIconConverter}">
+                            <Binding Path="IsDirectory" />
+                            <Binding Path="IsExpanded" />
+                        </MultiBinding>
+                    </Image.Source>
+                </Image>
+                <TextBox Text="{Binding Name}" VerticalAlignment="Center" />
+            </StackPanel>
+        </DataTemplate>
+    </Styles.Resources>
+    <Style Selector="TreeDataGrid TreeDataGridRow:nth-last-child(2n)">
+        <Setter Property="Background" Value="#20808080" />
+    </Style>
+    <Style Selector="TreeDataGrid :is(TreeDataGridCell):nth-last-child(1)">
+        <Setter Property="TextBlock.FontWeight" Value="Bold" />
+    </Style>
+    <Style Selector="TreeDataGrid TreeDataGridColumnHeader:nth-last-child(1)">
+        <Setter Property="TextBlock.FontWeight" Value="Bold" />
+    </Style>
+</Styles>

--- a/samples/avalonia/Gallery/App.fs
+++ b/samples/avalonia/Gallery/App.fs
@@ -79,7 +79,9 @@ module App =
         | TabControlPage
         | TabStripPage
         | TreeViewPage
+    #if PREMIUM_CONTROLS
         | TreeDataGridPage
+    #endif
         | TransitioningContentControlPage
         | ThemeAwarePage
         | UniformGridPage
@@ -181,7 +183,9 @@ module App =
         | "TabControl" -> ValueSome TabControlPage
         | "TabStrip" -> ValueSome TabStripPage
         | "TreeView" -> ValueSome TreeViewPage
+    #if PREMIUM_CONTROLS
         | "TreeDataGrid" -> ValueSome TreeDataGridPage
+    #endif
         | "TransitioningContent" -> ValueSome TransitioningContentControlPage
         | "ThemeAware" -> ValueSome ThemeAwarePage
         | "UniformGrid" -> ValueSome UniformGridPage
@@ -284,7 +288,9 @@ module App =
         | TabControlPage -> ValueSome(AnyView(TabControlPage.view()))
         | TabStripPage -> ValueSome(AnyView(TabStripPage.view()))
         | TreeViewPage -> ValueSome(AnyView(TreeViewPage.view()))
+    #if PREMIUM_CONTROLS
         | TreeDataGridPage -> ValueSome(AnyView(TreeDataGridPage.view()))
+    #endif
         | TransitioningContentControlPage -> ValueSome(AnyView(TransitioningContentControlPage.view()))
         | ThemeAwarePage -> ValueSome(AnyView(ThemeAwarePage.view()))
         | UniformGridPage -> ValueSome(AnyView(UniformGridPage.view()))

--- a/samples/avalonia/Gallery/App.xaml
+++ b/samples/avalonia/Gallery/App.xaml
@@ -7,7 +7,6 @@
     <labs:ControlThemes/>
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
     <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
-    <StyleInclude Source="avares://Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml" />
     <!--     <FluentTheme.Palettes> -->
     <!--         ~1~ Palette for Light theme variant @1@ -->
     <!--         <ColorPaletteResources x:Key="Light" Accent="Green" RegionColor="White" ErrorText="Red" /> -->
@@ -57,44 +56,6 @@
                     </Setter.Value>
                 </Setter>
             </ControlTheme>
-            <DataTemplate x:Key="RegionCell" DataType="gallery:Country">
-                <TextBlock Text="{Binding Region}" />
-            </DataTemplate>
-            <DataTemplate x:Key="RegionEditCell" DataType="gallery:Country">
-                <ComboBox ItemsSource="{x:Static gallery:Countries.Regions}"
-                          SelectedItem="{Binding Region}" />
-            </DataTemplate>
-            <!-- Template for Name column cells -->
-            <DataTemplate x:Key="FileNameCell" DataType="gallery:FileTreeNodeModel">
-                <StackPanel Orientation="Horizontal">
-                    <Image Margin="0 0 4 0"
-                           VerticalAlignment="Center">
-                        <Image.Source>
-                            <MultiBinding Converter="{x:Static gallery:FileTreeNodeModel.FileIconConverter}">
-                                <Binding Path="IsDirectory" />
-                                <Binding Path="IsExpanded" />
-                            </MultiBinding>
-                        </Image.Source>
-                    </Image>
-                    <TextBlock Text="{Binding Name}" VerticalAlignment="Center" />
-                </StackPanel>
-            </DataTemplate>
-
-            <!-- Edit template for Name column cells -->
-            <DataTemplate x:Key="FileNameEditCell" DataType="gallery:FileTreeNodeModel">
-                <StackPanel Orientation="Horizontal">
-                    <Image Margin="0 0 4 0"
-                           VerticalAlignment="Center">
-                        <Image.Source>
-                            <MultiBinding Converter="{x:Static gallery:FileTreeNodeModel.FileIconConverter}">
-                                <Binding Path="IsDirectory" />
-                                <Binding Path="IsExpanded" />
-                            </MultiBinding>
-                        </Image.Source>
-                    </Image>
-                    <TextBox Text="{Binding Name}" VerticalAlignment="Center" />
-                </StackPanel>
-            </DataTemplate>
         </ResourceDictionary>
     </Styles.Resources>
     <Style Selector="Button">
@@ -120,15 +81,6 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>
-    <Style Selector="TreeDataGrid TreeDataGridRow:nth-last-child(2n)">
-        <Setter Property="Background" Value="#20808080" />
-    </Style>
-    <Style Selector="TreeDataGrid :is(TreeDataGridCell):nth-last-child(1)">
-        <Setter Property="TextBlock.FontWeight" Value="Bold" />
-    </Style>
-    <Style Selector="TreeDataGrid TreeDataGridColumnHeader:nth-last-child(1)">
-        <Setter Property="TextBlock.FontWeight" Value="Bold" />
     </Style>
     <Style Selector="Thumb.drag">
         <Setter Property="ClipToBounds" Value="False" />

--- a/samples/avalonia/Gallery/Gallery.fsproj
+++ b/samples/avalonia/Gallery/Gallery.fsproj
@@ -11,6 +11,8 @@
     <WarningsAsErrors>FS0025</WarningsAsErrors>
     <NoWarn>MT7091;NETSDK1206</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <FabulousIncludePremiumControls Condition="'$(FabulousIncludePremiumControls)' == ''">false</FabulousIncludePremiumControls>
+    <DefineConstants Condition="'$(FabulousIncludePremiumControls)' == 'true'">$(DefineConstants);PREMIUM_CONTROLS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'Android'">
@@ -26,7 +28,8 @@
 
   <ItemGroup>
     <AvaloniaResource Include="Styles\*.xaml" />
-    <AvaloniaResource Include="*.xaml" />
+    <AvaloniaResource Include="*.xaml" Exclude="App.Premium.xaml" />
+    <AvaloniaResource Include="App.Premium.xaml" Condition="'$(FabulousIncludePremiumControls)' == 'true'" />
     <AvaloniaResource Include="Assets\**\*" />
     <AvaloniaResource Include="Assets\*" />
     <AvaloniaResource Include="Assets\Fonts\*" />
@@ -126,10 +129,10 @@
     <Compile Include="Pages\TreeView\TreeViewWithNodeInteraction.fs" />
     <Compile Include="Pages\TreeView\EditableTreeView.fs" />
     <Compile Include="Pages\TreeViewPage.fs" />
-    <Compile Include="Pages\TreeDataGrid\CountriesPage.fs" />
-    <Compile Include="Pages\TreeDataGrid\FileTreeNodeModel.fs" />
-    <Compile Include="Pages\TreeDataGrid\FilesPage.fs" />
-    <Compile Include="Pages\TreeDataGridPage.fs" />
+    <Compile Include="Pages\TreeDataGrid\CountriesPage.fs" Condition="'$(FabulousIncludePremiumControls)' == 'true'" />
+    <Compile Include="Pages\TreeDataGrid\FileTreeNodeModel.fs" Condition="'$(FabulousIncludePremiumControls)' == 'true'" />
+    <Compile Include="Pages\TreeDataGrid\FilesPage.fs" Condition="'$(FabulousIncludePremiumControls)' == 'true'" />
+    <Compile Include="Pages\TreeDataGridPage.fs" Condition="'$(FabulousIncludePremiumControls)' == 'true'" />
     <Compile Include="Pages\TransitioningContentControlPage.fs" />
     <Compile Include="Pages\UniformGridPage.fs" />
     <Compile Include="Pages\ShapesPage.fs" />
@@ -177,7 +180,7 @@
     <ProjectReference Include="..\..\..\src\avalonia\Fabulous.Avalonia.Diagnostics\Fabulous.Avalonia.Diagnostics.fsproj" />
     <ProjectReference Include="..\..\..\src\avalonia\Fabulous.Avalonia.ItemsRepeater\Fabulous.Avalonia.ItemsRepeater.fsproj" />
     <ProjectReference Include="..\..\..\src\avalonia\Fabulous.Avalonia.Labs\Fabulous.Avalonia.Labs.fsproj" />
-    <ProjectReference Include="..\..\..\src\avalonia\Fabulous.Avalonia.TreeDataGrid\Fabulous.Avalonia.TreeDataGrid.fsproj" />
+    <ProjectReference Include="..\..\..\src\avalonia\Fabulous.Avalonia.TreeDataGrid\Fabulous.Avalonia.TreeDataGrid.fsproj" Condition="'$(FabulousIncludePremiumControls)' == 'true'" />
     <ProjectReference Include="..\..\..\src\avalonia\Fabulous.Avalonia\Fabulous.Avalonia.fsproj" />
     <ProjectReference Include="..\ControlSamples\ControlSamples.csproj" />
   </ItemGroup>

--- a/samples/avalonia/Gallery/MainView.fs
+++ b/samples/avalonia/Gallery/MainView.fs
@@ -41,7 +41,7 @@ module MainView =
             { Details = detailPage }, Cmd.none
         | GoBack -> { Details = None }, Cmd.none
 
-    let controlNames =
+    let freeControlNames =
         [ "Acrylic"
           "AdornerLayer"
           "AutoCompleteBox"
@@ -109,7 +109,6 @@ module MainView =
           "ToolTip"
           "TabControl"
           "TreeView"
-          "TreeDataGrid"
           "TransitioningContent"
           "TabStrip"
           "ThemeAware"
@@ -132,6 +131,13 @@ module MainView =
           "Path Measurement"
           "Custom Animator"
           "SkCanvas" ]
+
+#if PREMIUM_CONTROLS
+    let premiumControlNames = [ "TreeDataGrid" ]
+    let controlNames = freeControlNames @ premiumControlNames
+#else
+    let controlNames = freeControlNames
+#endif
 
     let program =
         Program.statefulWithCmd init update
@@ -175,6 +181,10 @@ module MainView =
 
     let create () =
         let theme () =
+#if PREMIUM_CONTROLS
+            StyleInclude(baseUri = null, Source = Uri("avares://Gallery/App.Premium.xaml"))
+#else
             StyleInclude(baseUri = null, Source = Uri("avares://Gallery/App.xaml"))
+#endif
 
         FabulousAppBuilder.Configure(theme, view)

--- a/samples/avalonia/Gallery/MainWindow.fs
+++ b/samples/avalonia/Gallery/MainWindow.fs
@@ -209,7 +209,9 @@ module MainWindow =
             TabItem("ToolTipPage", ToolTipPage.view())
             TabItem("TabControlPage", TabControlPage.view())
             TabItem("TreeViewPage", TreeViewPage.view())
+#if PREMIUM_CONTROLS
             TabItem("TreeDataGridViewPage", TreeDataGridPage.view())
+#endif
             TabItem("TransitioningContentPage", TransitioningContentControlPage.view())
             TabItem("TabStripPage", TabStripPage.view())
             TabItem("ThemeAwarePage", ThemeAwarePage.view())
@@ -322,6 +324,10 @@ module MainWindow =
 
     let create () =
         let theme () =
+#if PREMIUM_CONTROLS
+            StyleInclude(baseUri = null, Source = Uri("avares://Gallery/App.Premium.xaml"))
+#else
             StyleInclude(baseUri = null, Source = Uri("avares://Gallery/App.xaml"))
+#endif
 
         FabulousAppBuilder.Configure(theme, view)


### PR DESCRIPTION
## Summary

- build screenshot-only Android APKs in Debug with embedded assemblies, avoiding Release AOT/trimming while retaining the separate optimized Android smoke job
- split Avalonia logic/headless tests from four parallel screenshot-capture shards
- distribute the 90 Gallery views across all four shards and aggregate screenshots back into the existing `Screenshots-Avalonia` artifact
- retry X11 capture against the current visible window when a stale window ID causes ImageMagick `import` to fail
- skip redundant restore evaluation for already-built Avalonia launches

## Motivation

In run 32726499544, Android restores took under four seconds per sample, but Release optimization took roughly 80-90 seconds per app and made a four-app shard take 7m19s. The serial Avalonia capture remained active for over 45 minutes because Gallery alone has 90 views. NuGet caching does not address either dominant cost.

## Validation

- `actionlint .github/workflows/pull_request.yml`
- YAML and artifact aggregation checks
- shell syntax checks for both capture scripts
- repository inventory and whitespace validation
- verified Debug Android evaluates with AOT/trimming disabled, `AndroidLinkMode=None`, and embedded assemblies enabled
- verified all 110 Avalonia captures are uniquely balanced as 28/28/27/27 work units
- forced every first X11 import attempt to fail in a complete shard; all 28 captures succeeded on re-resolved window IDs
- built Avalonia Gallery successfully in Debug