### PR TITLE
Document Avalonia premium control licensing

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,5 +28,6 @@
 ## Avalonia
 
 * [Get Started](avalonia/get-started.md)
+* [Licensing](avalonia/licensing.md)
 * [Migrate to Avalonia 12](avalonia/migrate-to-12.md)
 * [API reference](api/README.md)

--- a/docs/avalonia/get-started.md
+++ b/docs/avalonia/get-started.md
@@ -1,5 +1,7 @@
 # Get Started
 
+The templates use Avalonia's free, open-source core framework and standard controls. Some optional Avalonia controls are commercial products; see [Avalonia licensing](licensing.md) before adding extensions such as TreeDataGrid.
+
 ## Install the templates
 
 \

--- a/docs/avalonia/licensing.md
+++ b/docs/avalonia/licensing.md
@@ -1,0 +1,20 @@
+# Avalonia licensing
+
+Avalonia uses a freemium product model. The core Avalonia framework and its standard controls are open source and free to use. Avalonia also offers premium controls that require a commercial Avalonia license. Fabulous.Avalonia is open source, but a Fabulous wrapper does not include or replace the license for its underlying Avalonia control.
+
+At the time of writing, Avalonia lists these premium controls:
+
+* [Media Player](https://avaloniaui.net/media-player)
+* [TreeDataGrid](https://avaloniaui.net/tree-data-grid)
+* [Markdown Viewer](https://avaloniaui.net/markdown-viewer)
+* [On-Screen Keyboard](https://avaloniaui.net/on-screen-keyboard)
+* [70+ Charts](https://avaloniaui.net/charts)
+* [Rich Text Editor](https://avaloniaui.net/rich-text-editor)
+
+Avalonia's current pricing lists the premium controls in the Pro tier and component source code in the Enterprise tier. Product availability and terms can change, so check the linked product page and [Avalonia pricing](https://avaloniaui.net/pricing) before adopting one.
+
+## Using premium controls
+
+Add a premium control only after deciding how its Avalonia license will be supplied to every executable project that uses it. Follow that control's official setup instructions; installing a Fabulous extension package alone is not sufficient.
+
+For CI and release builds, keep license keys in the CI provider's secret store. Do not commit a key to the project file or repository. If a CI job has no license, exclude the premium control from that job rather than treating its license error as a product failure.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -9,6 +9,8 @@ You'll need to choose a "flavor" of Fabulous first:
 
 The flavor you choose will determine the requirements, the available widgets and the supported platforms you can target.
 
+Avalonia uses a freemium model: its core framework and standard controls are free and open source, while selected premium controls require a commercial license. Review [Avalonia licensing](avalonia/licensing.md) before choosing extension controls.
+
 Once chosen, please refer to the corresponding "Get Started" documentation to learn more about writing an app with that flavor.
 
 | Flavor                     | Documentation                              |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - MAUI virtualized collections: maui/virtualized-collections.md
       - MAUI Route-based navigation: maui/navigation.md
       - Avalonia: avalonia/get-started.md
+      - Avalonia licensing: avalonia/licensing.md
       - Migrate to Avalonia 12: avalonia/migrate-to-12.md
   - Core concepts:
     - Programs and commands: concepts/programs.md

--- a/docs/tutorials/avalonia.md
+++ b/docs/tutorials/avalonia.md
@@ -2,6 +2,8 @@
 
 This tutorial creates a desktop Fabulous 10 application, connects MVU state to Avalonia widgets, runs tests, and prepares a release build. Use the multi-platform template only when you also need Android or iOS hosts.
 
+The template and standard Avalonia controls do not require a commercial control license. Avalonia also offers premium controls under a freemium model; read [Avalonia licensing](../avalonia/licensing.md) before adding extension controls.
+
 ## Create and run
 
 ```bash

--- a/src/avalonia/Fabulous.Avalonia.TreeDataGrid/README.md
+++ b/src/avalonia/Fabulous.Avalonia.TreeDataGrid/README.md
@@ -2,6 +2,8 @@
 
 The tree data grid displays hierarchical and tabular data together in a single view. It is a combination of a tree view and data grid.. See the [Avalonia documentation](https://docs.avaloniaui.net/docs/next/reference/controls/detailed-reference/treedatagrid/) for more information.
 
+> **License required:** Avalonia TreeDataGrid is a [premium Avalonia control](https://avaloniaui.net/tree-data-grid) and requires a commercial Avalonia license. The `Fabulous.Avalonia.TreeDataGrid` package provides a Fabulous wrapper but does not include that license. See the [Fabulous Avalonia licensing guide](https://fabulous-dev.github.io/Fabulous/docs/avalonia/licensing/).
+
 ### How to use
 - Add the `Fabulous.Avalonia.TreeDataGrid` package to your project.
 - Open `Fabulous.Avalonia` at the top of the file where you declare your Fabulous program (eg. Program.stateful).

--- a/src/avalonia/Fabulous.Avalonia/README.md
+++ b/src/avalonia/Fabulous.Avalonia/README.md
@@ -4,6 +4,8 @@ Fabulous.Avalonia brings the great development experience of Fabulous to Avaloni
 
 Deploy to any platform supported by Avalonia, such as Android, iOS, macOS, Windows, Linux and more!
 
+Avalonia's core framework and standard controls are free and open source, while selected premium controls require a commercial Avalonia license. See the [Fabulous Avalonia licensing guide](https://fabulous-dev.github.io/Fabulous/docs/avalonia/licensing/) before adding extension controls.
+
 ## Getting Started
 
 You can start your new Fabulous.Avalonia app in a matter of seconds using the dotnet CLI templates.  


### PR DESCRIPTION
## Summary

- explain Avalonia's freemium model: MIT/free core framework and standard controls, with six premium controls in commercial tiers
- list and link Media Player, TreeDataGrid, Markdown Viewer, On-Screen Keyboard, Charts, and Rich Text Editor
- clarify that Pro includes premium controls while Enterprise adds component source code
- explain license handling for executable projects and CI secrets
- link the guidance from the backend chooser, Avalonia tutorial, Avalonia get-started page, MkDocs/GitBook navigation, and the core package README
- add a direct license warning to the `Fabulous.Avalonia.TreeDataGrid` package README

## Validation

- all relative documentation links resolve
- all seven official Avalonia product/pricing URLs are present exactly once on the canonical page
- `docs/mkdocs.yml` parses and includes the licensing page in navigation
- repository inventory and whitespace checks pass

MkDocs is not installed in the local environment, so rendering is left to documentation CI.