### PR TITLE
Fix MAUI deprecation warnings

### DIFF
--- a/samples/avalonia/Component/TicTacToe/App.fs
+++ b/samples/avalonia/Component/TicTacToe/App.fs
@@ -199,13 +199,19 @@ module App =
                     visualBoardSize.Set(size)
 #else
                     let window = app.FindWindowById("MainWindow") |> Option.get
-                    let desiredSize = window.Screens.Primary
 
-                    let size =
-                        Math.Min(float desiredSize.Bounds.Width, float desiredSize.Bounds.Height)
-                        / desiredSize.Scaling
+                    let screen =
+                        window.Screens.Primary
+                        |> Option.ofObj
+                        |> Option.orElseWith(fun () -> window.Screens.All |> Seq.tryHead)
 
-                    visualBoardSize.Set(size)
+                    match screen with
+                    | Some screen ->
+                        let size =
+                            Math.Min(float screen.Bounds.Width, float screen.Bounds.Height) / screen.Scaling
+
+                        visualBoardSize.Set(size)
+                    | None -> ()
 #endif
                 )
         }

--- a/samples/avalonia/Mvu/TicTacToe/App.fs
+++ b/samples/avalonia/Mvu/TicTacToe/App.fs
@@ -133,15 +133,21 @@ module App =
             { model with VisualBoardSize = size }, Cmd.none
 #else
             let window = app.FindWindowById("MainWindow") |> Option.get
-            let desiredSize = window.Screens.Primary
 
-            let size =
-                Math.Min(float desiredSize.Bounds.Width, float desiredSize.Bounds.Height)
-                / desiredSize.Scaling
+            let screen =
+                window.Screens.Primary
+                |> Option.ofObj
+                |> Option.orElseWith(fun () -> window.Screens.All |> Seq.tryHead)
 
-            { model with
-                VisualBoardSize = size - 40. },
-            Cmd.none
+            match screen with
+            | Some screen ->
+                let size =
+                    Math.Min(float screen.Bounds.Width, float screen.Bounds.Height) / screen.Scaling
+
+                { model with
+                    VisualBoardSize = size - 40. },
+                Cmd.none
+            | None -> model, Cmd.none
 #endif
         | Play pos ->
             let newModel =

--- a/src/maui/Fabulous.MauiControls/Views/Application.fs
+++ b/src/maui/Fabulous.MauiControls/Views/Application.fs
@@ -1,5 +1,7 @@
 ﻿namespace Fabulous.Maui
 
+#nowarn "44"
+
 open System
 open System.Collections.Generic
 open System.Runtime.CompilerServices

--- a/src/maui/Fabulous.MauiControls/Views/Cells/ImageCell.fs
+++ b/src/maui/Fabulous.MauiControls/Views/Cells/ImageCell.fs
@@ -1,5 +1,7 @@
 namespace Fabulous.Maui
 
+#nowarn "44"
+
 open System
 open System.IO
 open System.Runtime.CompilerServices

--- a/src/maui/Fabulous.MauiControls/Views/Cells/TextCell.fs
+++ b/src/maui/Fabulous.MauiControls/Views/Cells/TextCell.fs
@@ -1,5 +1,7 @@
 namespace Fabulous.Maui
 
+#nowarn "44"
+
 open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui.Controls

--- a/src/maui/Fabulous.MauiControls/Views/Cells/ViewCell.fs
+++ b/src/maui/Fabulous.MauiControls/Views/Cells/ViewCell.fs
@@ -1,5 +1,7 @@
 namespace Fabulous.Maui
 
+#nowarn "44"
+
 open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui.Controls

--- a/src/maui/Fabulous.MauiControls/Views/Collections/ListView.fs
+++ b/src/maui/Fabulous.MauiControls/Views/Collections/ListView.fs
@@ -1,5 +1,7 @@
 namespace Fabulous.Maui
 
+#nowarn "44"
+
 open System
 open System.Runtime.CompilerServices
 open Fabulous

--- a/src/maui/Fabulous.MauiControls/Views/_VisualElement.fs
+++ b/src/maui/Fabulous.MauiControls/Views/_VisualElement.fs
@@ -156,64 +156,64 @@ module VisualElementAnimations =
             let view = node.Target :?> View
 
             match newValueOpt with
-            | ValueNone -> view.FadeTo(0., uint 0, Easing.Linear) |> ignore
-            | ValueSome data -> view.FadeTo(data.Opacity, data.AnimationDuration, data.Easing) |> ignore)
+            | ValueNone -> view.FadeToAsync(0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.FadeToAsync(data.Opacity, data.AnimationDuration, data.Easing) |> ignore)
 
     let RotateTo =
         Attributes.defineSimpleScalarWithEquality<RotateToData> "VisualElement_RotateTo" (fun _ newValueOpt node ->
             let view = node.Target :?> View
 
             match newValueOpt with
-            | ValueNone -> view.RotateTo(0., uint 0, Easing.Linear) |> ignore
-            | ValueSome data -> view.RotateTo(data.Rotation, data.AnimationDuration, data.Easing) |> ignore)
+            | ValueNone -> view.RotateToAsync(0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.RotateToAsync(data.Rotation, data.AnimationDuration, data.Easing) |> ignore)
 
     let RotateXTo =
         Attributes.defineSimpleScalarWithEquality<RotateToData> "VisualElement_RotateXTo" (fun _ newValueOpt node ->
             let view = node.Target :?> View
 
             match newValueOpt with
-            | ValueNone -> view.RotateXTo(0., uint 0, Easing.Linear) |> ignore
-            | ValueSome data -> view.RotateXTo(data.Rotation, data.AnimationDuration, data.Easing) |> ignore)
+            | ValueNone -> view.RotateXToAsync(0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.RotateXToAsync(data.Rotation, data.AnimationDuration, data.Easing) |> ignore)
 
     let RotateYTo =
         Attributes.defineSimpleScalarWithEquality<RotateToData> "VisualElement_RotateYTo" (fun _ newValueOpt node ->
             let view = node.Target :?> View
 
             match newValueOpt with
-            | ValueNone -> view.RotateYTo(0., uint 0, Easing.Linear) |> ignore
-            | ValueSome data -> view.RotateYTo(data.Rotation, data.AnimationDuration, data.Easing) |> ignore)
+            | ValueNone -> view.RotateYToAsync(0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.RotateYToAsync(data.Rotation, data.AnimationDuration, data.Easing) |> ignore)
 
     let ScaleTo =
         Attributes.defineSimpleScalarWithEquality<ScaleToData> "VisualElement_ScaleTo" (fun _ newValueOpt node ->
             let view = node.Target :?> View
 
             match newValueOpt with
-            | ValueNone -> view.ScaleTo(1., uint 0, Easing.Linear) |> ignore
-            | ValueSome data -> view.ScaleTo(data.Scale, data.AnimationDuration, data.Easing) |> ignore)
+            | ValueNone -> view.ScaleToAsync(1., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.ScaleToAsync(data.Scale, data.AnimationDuration, data.Easing) |> ignore)
 
     let ScaleXTo =
         Attributes.defineSimpleScalarWithEquality<ScaleToData> "VisualElement_ScaleXTo" (fun _ newValueOpt node ->
             let view = node.Target :?> View
 
             match newValueOpt with
-            | ValueNone -> view.ScaleXTo(1., uint 0, Easing.Linear) |> ignore
-            | ValueSome data -> view.ScaleXTo(data.Scale, data.AnimationDuration, data.Easing) |> ignore)
+            | ValueNone -> view.ScaleXToAsync(1., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.ScaleXToAsync(data.Scale, data.AnimationDuration, data.Easing) |> ignore)
 
     let ScaleYTo =
         Attributes.defineSimpleScalarWithEquality<ScaleToData> "VisualElement_ScaleYTo" (fun _ newValueOpt node ->
             let view = node.Target :?> View
 
             match newValueOpt with
-            | ValueNone -> view.ScaleYTo(1., uint 0, Easing.Linear) |> ignore
-            | ValueSome data -> view.ScaleYTo(data.Scale, data.AnimationDuration, data.Easing) |> ignore)
+            | ValueNone -> view.ScaleYToAsync(1., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.ScaleYToAsync(data.Scale, data.AnimationDuration, data.Easing) |> ignore)
 
     let TranslateTo =
         Attributes.defineSimpleScalarWithEquality<TranslateToData> "VisualElement_TranslateTo" (fun _ newValueOpt node ->
             let view = node.Target :?> View
 
             match newValueOpt with
-            | ValueNone -> view.TranslateTo(0., 0., uint 0, Easing.Linear) |> ignore
-            | ValueSome data -> view.TranslateTo(data.X, data.Y, data.AnimationDuration, data.Easing) |> ignore)
+            | ValueNone -> view.TranslateToAsync(0., 0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.TranslateToAsync(data.X, data.Y, data.AnimationDuration, data.Easing) |> ignore)
 
 [<Extension>]
 type VisualElementModifiers =


### PR DESCRIPTION
## Summary

- use the renamed async MAUI animation APIs
- suppress deprecation warnings for retained `ListView`, cell, and legacy `Application.MainPage` compatibility surfaces
- preserve the existing public Fabulous APIs and behavior
- cover the duplicate warning sets emitted by both affected CI jobs

## Validation

Not run locally, per request. CI will validate the changes.