### PR TITLE
Fix website community links

### DIFF
--- a/website/themes/fabulous.dev-theme/layouts/partials/footer.html
+++ b/website/themes/fabulous.dev-theme/layouts/partials/footer.html
@@ -8,7 +8,6 @@
     <div class="footer-social">
         <ul>
             <li><a href="https://github.com/fabulous-dev/Fabulous"><i class="fa-brands fa-github"></i></a></li>
-            <li><a rel="me" href="https://mastodon.social/@FabulousAppDev"><i class="fa-brands fa-mastodon"></i></a></li>
             <li><a href="https://discord.com/channels/196693847965696000/1541149327701971026"><i class="fa-brands fa-discord"></i></a></li>
         </ul>
     </div>

--- a/website/themes/fabulous.dev-theme/layouts/partials/header.html
+++ b/website/themes/fabulous.dev-theme/layouts/partials/header.html
@@ -3,7 +3,7 @@
 
 <header>
     <div class="logo">
-        <a href="/">
+        <a href="https://fabulous-dev.github.io/Fabulous/">
             <img src="{{ $logo.RelPermalink }}" alt="Fabulous" />
             Fabulous
         </a>
@@ -20,11 +20,10 @@
         <div class="left-menu">
             <a class="menu-item" href="{{ "docs/" | relURL }}">Documentation</a>
             <a class="menu-item" href="https://fabulous.dev/about" style="display: none;">About</a>
-            <a class="menu-item" href="mailto:maintainers@fabulous.dev">Contact us</a>
+            <a class="menu-item" href="https://discord.com/channels/196693847965696000/1541149327701971026">Contact us</a>
         </div>
         <div class="right-menu">
             <a href="https://github.com/fabulous-dev/Fabulous"><i class="fa-brands fa-github"></i></a>
-            <a rel="me" href="https://mastodon.social/@FabulousAppDev"><i class="fa-brands fa-mastodon"></i></a>
             <a href="https://discord.com/channels/196693847965696000/1541149327701971026"><i class="fa-brands fa-discord"></i></a>
         </div>
     </div>


### PR DESCRIPTION
## Summary

- link the landing-page Fabulous logo to the GitHub Pages site under `/Fabulous/`
- route **Contact us** to the Fabulous Discord channel
- remove Mastodon links from the header and footer

## Validation

- source assertions verified the exact logo and Discord targets and confirmed Mastodon references are absent from `website/`
- `git diff --check`
- editor template diagnostics

A local Hugo render was not run because Hugo is not installed in the environment.
