### PR TITLE
Fix merged main CI failures

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -438,7 +438,7 @@ jobs:
             }
             $projectDirectory = Split-Path $sample.Project
             $projectName = [System.IO.Path]::GetFileNameWithoutExtension($sample.Project)
-            $executable = Get-ChildItem "$projectDirectory/bin/$env:CONFIG" -Recurse -Filter "$projectName.exe" | Select-Object -First 1
+            $executable = Get-ChildItem "$projectDirectory/bin" -Recurse -Filter "$projectName.exe" | Select-Object -First 1
             if (-not $executable) {
               throw "The $($sample.Name) WinUI compatibility executable was not produced."
             }

--- a/eng/ci/capture-avalonia-samples.sh
+++ b/eng/ci/capture-avalonia-samples.sh
@@ -14,6 +14,7 @@ fi
 
 mapfile -d '' projects < <(
   find samples/avalonia -name '*.fsproj' \
+    ! -path '*/TestableApp/TestableApp.fsproj' \
     ! -path '*/TestableApp.UnitTests/*' \
     ! -path '*/TestableApp.Headless.XUnit/*' \
     -print0 | sort -z

--- a/samples/maui/WinUICompat/HelloWorld.Fabulous/App.fs
+++ b/samples/maui/WinUICompat/HelloWorld.Fabulous/App.fs
@@ -17,7 +17,7 @@ module App =
     type CmdMsg = SemanticAnnounce of string
 
     let semanticAnnounce text =
-        Cmd.ofSub(fun _ -> SemanticScreenReader.Announce(text))
+        Cmd.ofEffect(fun _ -> SemanticScreenReader.Announce(text))
 
     let mapCmd cmdMsg =
         match cmdMsg with
@@ -31,19 +31,12 @@ module App =
 
     let view model =
         Application(
-            ContentPage(
-                "HelloWorld",
+            (ContentPage(
                 ScrollView(
                     (VStack(spacing = 25.) {
-                        Image(Aspect.AspectFit, "dotnet_bot.png")
-                            .semantics(description = "Cute dotnet bot waving hi to you!")
-                            .height(200.)
-                            .centerHorizontal()
+                        Image("dotnet_bot.png", Aspect.AspectFit).semantics(description = "Cute dotnet bot waving hi to you!").height(200.).centerHorizontal()
 
-                        Label("Hello, World!")
-                            .semantics(SemanticHeadingLevel.Level1)
-                            .font(size = 32.)
-                            .centerTextHorizontal()
+                        Label("Hello, World!").semantics(SemanticHeadingLevel.Level1).font(size = 32.).centerTextHorizontal()
 
                         Label("Welcome to .NET Multi-platform App UI powered by Fabulous")
                             .semantics(SemanticHeadingLevel.Level2, "Welcome to dot net Multi platform App U I powered by Fabulous")
@@ -56,16 +49,16 @@ module App =
                             else
                                 $"Clicked {model.Count} times"
 
-                        Button(text, Clicked)
-                            .semantics(hint = "Counts the number of times you click")
-                            .centerHorizontal()
+                        Button(text, Clicked).semantics(hint = "Counts the number of times you click").centerHorizontal()
                     })
                         .padding(Thickness(30., 0., 30., 0.))
                         .centerVertical()
                 )
-            )
+            ))
+                .title("HelloWorld")
         )
 
     let program =
-        Program.statefulWithCmdMsg init update view mapCmd
-        |> Program.withLogger { ViewHelpers.defaultLogger() with MinLogLevel = LogLevel.Debug }
+        Program.statefulWithCmdMsg init update mapCmd
+        |> Program.withTrace System.Console.WriteLine
+        |> Program.withView view

--- a/src/maui/FSharp.Maui.WinUICompat/FSharp.Maui.WinUICompat.csproj
+++ b/src/maui/FSharp.Maui.WinUICompat/FSharp.Maui.WinUICompat.csproj
@@ -14,6 +14,7 @@
   <PropertyGroup>
     <Description>Enables compiling a Maui application targeting WinUI</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
   <!-- SourceLink -->


### PR DESCRIPTION
## Summary

- locate unpackaged WinUI sample executables under the platform-aware `bin/x64/Release` output tree
- suppress expected missing XML documentation warnings in the generated WinUI compatibility surface
- exclude the intentionally windowless `TestableApp` fixture from desktop screenshot capture while retaining its unit and headless UI coverage

## Initial evidence

- MSBuild evaluates both WinUI sample outputs under `bin/x64/Release/net10.0-windows10.0.19041.0/win-x64`
- `TestableApp` starts a bare desktop lifetime without configuring a visible window and is already covered by dedicated unit and headless jobs

Further validation and any necessary corrections will be pushed to this PR.