### PR TITLE
Reduce pull request CI coverage

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJSON(github.event_name == 'push' && '[0,1,2,3]' || '[0]') }}
+        shard: [0, 1, 2, 3]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -182,11 +182,12 @@ jobs:
 
   maui-android-package:
     name: MAUI Android package shard ${{ matrix.shard }}
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJSON(github.event_name == 'push' && '[0,1,2,3]' || '[0]') }}
+        shard: [0, 1, 2, 3]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -202,10 +203,9 @@ jobs:
       - name: Install Android workload
         run: dotnet workload install maui-android --skip-manifest-update
       - name: Build Android sample shard
-        run: bash eng/ci/capture-maui-android-samples.sh build ${{ matrix.shard }} ${{ github.event_name == 'push' && 4 || 1 }}
+        run: bash eng/ci/capture-maui-android-samples.sh build ${{ matrix.shard }} 4
         env:
           CONFIG: Debug
-          FABULOUS_SAMPLE_CAPTURE_MODE: ${{ github.event_name == 'push' && 'all' || 'gallery' }}
       - name: Upload signed Android packages
         uses: actions/upload-artifact@v4
         with:
@@ -216,6 +216,7 @@ jobs:
   maui-android-samples:
     name: MAUI Android sample runtime tests
     needs: maui-android-package
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -232,7 +233,7 @@ jobs:
             | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Run and capture Android samples
+      - name: Run and capture every Android sample
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
@@ -241,8 +242,6 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: bash eng/ci/capture-maui-android-samples.sh capture
-        env:
-          FABULOUS_SAMPLE_CAPTURE_MODE: ${{ github.event_name == 'push' && 'all' || 'gallery' }}
       - name: Upload screenshots
         if: always()
         uses: actions/upload-artifact@v4
@@ -254,6 +253,7 @@ jobs:
   avalonia-template:
     name: Avalonia template (${{ matrix.template }})
     needs: build-and-test
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -304,6 +304,7 @@ jobs:
 
   android-runtime:
     name: Android build and launch
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -344,6 +345,7 @@ jobs:
 
   apple-runtime:
     name: Apple build and launch
+    if: github.event_name == 'push'
     runs-on: macos-26
     steps:
       - name: Checkout sources
@@ -393,6 +395,7 @@ jobs:
   windows-compat:
     name: Windows compatibility
     needs: build-and-test
+    if: github.event_name == 'push'
     runs-on: windows-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -119,6 +119,7 @@ jobs:
         env:
           FABULOUS_SCREENSHOT_DIR: ${{ github.workspace }}/artifacts/screenshots/avalonia-headless
       - name: Upload headless screenshots
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: Avalonia-Headless-Screenshots
@@ -131,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: ${{ fromJSON(github.event_name == 'push' && '[0,1,2,3]' || '[0]') }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -150,9 +151,10 @@ jobs:
       - name: Install desktop capture tools
         run: sudo apt-get update && sudo apt-get install -y imagemagick xdotool xvfb
       - name: Build, run, and capture sample shard
-        run: xvfb-run --auto-servernum --server-args='-screen 0 1440x900x24' bash eng/ci/capture-avalonia-samples.sh ${{ matrix.shard }} 4
+        run: xvfb-run --auto-servernum --server-args='-screen 0 1440x900x24' bash eng/ci/capture-avalonia-samples.sh ${{ matrix.shard }} ${{ github.event_name == 'push' && 4 || 1 }}
         env:
           CONFIG: Debug
+          FABULOUS_SAMPLE_CAPTURE_MODE: ${{ github.event_name == 'push' && 'all' || 'gallery' }}
       - name: Upload shard screenshots
         uses: actions/upload-artifact@v4
         with:
@@ -168,7 +170,7 @@ jobs:
       - name: Download screenshots
         uses: actions/download-artifact@v4
         with:
-          pattern: Avalonia-*Screenshots*
+          pattern: Avalonia-Screenshots-*
           path: artifacts/screenshots/
           merge-multiple: true
       - name: Upload screenshots
@@ -184,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: ${{ fromJSON(github.event_name == 'push' && '[0,1,2,3]' || '[0]') }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -200,9 +202,10 @@ jobs:
       - name: Install Android workload
         run: dotnet workload install maui-android --skip-manifest-update
       - name: Build Android sample shard
-        run: bash eng/ci/capture-maui-android-samples.sh build ${{ matrix.shard }} 4
+        run: bash eng/ci/capture-maui-android-samples.sh build ${{ matrix.shard }} ${{ github.event_name == 'push' && 4 || 1 }}
         env:
           CONFIG: Debug
+          FABULOUS_SAMPLE_CAPTURE_MODE: ${{ github.event_name == 'push' && 'all' || 'gallery' }}
       - name: Upload signed Android packages
         uses: actions/upload-artifact@v4
         with:
@@ -229,7 +232,7 @@ jobs:
             | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Run and capture every Android sample
+      - name: Run and capture Android samples
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
@@ -238,6 +241,8 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: bash eng/ci/capture-maui-android-samples.sh capture
+        env:
+          FABULOUS_SAMPLE_CAPTURE_MODE: ${{ github.event_name == 'push' && 'all' || 'gallery' }}
       - name: Upload screenshots
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: ${{ fromJSON(github.event_name == 'push' && '[0,1,2,3]' || '[0]') }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/eng/ci/capture-avalonia-samples.sh
+++ b/eng/ci/capture-avalonia-samples.sh
@@ -3,22 +3,32 @@ set -euo pipefail
 
 configuration="${CONFIG:-Release}"
 output_dir="${FABULOUS_SCREENSHOT_DIR:-$PWD/artifacts/screenshots/avalonia}"
+capture_mode="${FABULOUS_SAMPLE_CAPTURE_MODE:-all}"
 shard_index="${1:-0}"
 shard_count="${2:-1}"
 mkdir -p "$output_dir"
+
+if [[ "$capture_mode" != "all" && "$capture_mode" != "gallery" ]]; then
+  echo "Invalid capture mode: $capture_mode." >&2
+  exit 2
+fi
 
 if ((shard_index < 0 || shard_index >= shard_count)); then
   echo "Invalid shard $shard_index of $shard_count." >&2
   exit 2
 fi
 
-mapfile -d '' projects < <(
-  find samples/avalonia -name '*.fsproj' \
-    ! -path '*/TestableApp/TestableApp.fsproj' \
-    ! -path '*/TestableApp.UnitTests/*' \
-    ! -path '*/TestableApp.Headless.XUnit/*' \
-    -print0 | sort -z
-)
+if [[ "$capture_mode" == "gallery" ]]; then
+  projects=("samples/avalonia/Gallery/Gallery.fsproj")
+else
+  mapfile -d '' projects < <(
+    find samples/avalonia -name '*.fsproj' \
+      ! -path '*/TestableApp/TestableApp.fsproj' \
+      ! -path '*/TestableApp.UnitTests/*' \
+      ! -path '*/TestableApp.Headless.XUnit/*' \
+      -print0 | sort -z
+  )
+fi
 
 test "${#projects[@]}" -gt 0
 printf 'Capturing Avalonia sample shard %d of %d.\n' "$shard_index" "$shard_count"
@@ -44,7 +54,7 @@ for project_index in "${!projects[@]}"; do
   echo "::endgroup::"
 
   pages=("")
-  if [[ "$is_gallery" == true ]]; then
+  if [[ "$is_gallery" == true && "$capture_mode" == "all" ]]; then
     mapfile -t gallery_pages < <(python3 - <<'PY'
 import re
 from pathlib import Path

--- a/eng/ci/capture-maui-android-samples.sh
+++ b/eng/ci/capture-maui-android-samples.sh
@@ -4,8 +4,14 @@ set -euo pipefail
 configuration="${CONFIG:-Release}"
 output_dir="${FABULOUS_SCREENSHOT_DIR:-$PWD/artifacts/screenshots/maui-android}"
 package_dir="${FABULOUS_ANDROID_PACKAGE_DIR:-$PWD/artifacts/android-packages}"
+capture_mode="${FABULOUS_SAMPLE_CAPTURE_MODE:-all}"
 coverage="$output_dir/coverage.tsv"
 mkdir -p "$output_dir" "$package_dir"
+
+if [[ "$capture_mode" != "all" && "$capture_mode" != "gallery" ]]; then
+  echo "Invalid capture mode: $capture_mode." >&2
+  exit 2
+fi
 
 assert_png() {
   python3 - "$1" <<'PY'
@@ -94,11 +100,15 @@ path.write_text("\n".join(replacement if line == expected else line for line in 
 PY
 }
 
-mapfile -d '' projects < <(
-  find samples/maui -name '*.fsproj' \
-    ! -path '*/WinUICompat/*' \
-    -print0 | sort -z
-)
+if [[ "$capture_mode" == "gallery" ]]; then
+  projects=("samples/maui/Gallery/Gallery.fsproj")
+else
+  mapfile -d '' projects < <(
+    find samples/maui -name '*.fsproj' \
+      ! -path '*/WinUICompat/*' \
+      -print0 | sort -z
+  )
+fi
 
 test "${#projects[@]}" -gt 0
 
@@ -192,7 +202,7 @@ capture_samples() {
     adb exec-out screencap -p >"$screenshot"
     assert_png "$screenshot"
 
-    if [[ "$relative" == "Gallery/Gallery.fsproj" ]]; then
+    if [[ "$relative" == "Gallery/Gallery.fsproj" && "$capture_mode" == "all" ]]; then
       capture_gallery_pages "$slug" "$application_id"
     fi
     mark_captured "$relative"

--- a/eng/ci/capture-maui-android-samples.sh
+++ b/eng/ci/capture-maui-android-samples.sh
@@ -4,14 +4,8 @@ set -euo pipefail
 configuration="${CONFIG:-Release}"
 output_dir="${FABULOUS_SCREENSHOT_DIR:-$PWD/artifacts/screenshots/maui-android}"
 package_dir="${FABULOUS_ANDROID_PACKAGE_DIR:-$PWD/artifacts/android-packages}"
-capture_mode="${FABULOUS_SAMPLE_CAPTURE_MODE:-all}"
 coverage="$output_dir/coverage.tsv"
 mkdir -p "$output_dir" "$package_dir"
-
-if [[ "$capture_mode" != "all" && "$capture_mode" != "gallery" ]]; then
-  echo "Invalid capture mode: $capture_mode." >&2
-  exit 2
-fi
 
 assert_png() {
   python3 - "$1" <<'PY'
@@ -100,15 +94,11 @@ path.write_text("\n".join(replacement if line == expected else line for line in 
 PY
 }
 
-if [[ "$capture_mode" == "gallery" ]]; then
-  projects=("samples/maui/Gallery/Gallery.fsproj")
-else
-  mapfile -d '' projects < <(
-    find samples/maui -name '*.fsproj' \
-      ! -path '*/WinUICompat/*' \
-      -print0 | sort -z
-  )
-fi
+mapfile -d '' projects < <(
+  find samples/maui -name '*.fsproj' \
+    ! -path '*/WinUICompat/*' \
+    -print0 | sort -z
+)
 
 test "${#projects[@]}" -gt 0
 
@@ -202,7 +192,7 @@ capture_samples() {
     adb exec-out screencap -p >"$screenshot"
     assert_png "$screenshot"
 
-    if [[ "$relative" == "Gallery/Gallery.fsproj" && "$capture_mode" == "all" ]]; then
+    if [[ "$relative" == "Gallery/Gallery.fsproj" ]]; then
       capture_gallery_pages "$slug" "$application_id"
     fi
     mark_captured "$relative"


### PR DESCRIPTION
## Summary

- keep repository validation, core build/test/package validation, and Avalonia sample tests on pull requests
- capture one representative Avalonia Gallery screenshot on pull requests
- run Windows compatibility, Apple build/launch, Android build/launch, and Avalonia template checks only after changes reach `main`
- run the complete four-shard MAUI Android package, emulator, and screenshot flow only after changes reach `main`
- retain the complete four-shard Avalonia project/page capture matrix on `main`

## Coverage policy

| Check | Pull request | Push to `main` |
| --- | --- | --- |
| Core validation, build, test, and package | Yes | Yes |
| Avalonia sample tests | Yes | Yes |
| Avalonia runtime screenshots | Gallery default view, 1 PNG | Full project/page matrix, 4 shards |
| Windows compatibility | Skipped | Yes |
| Apple build and launch | Skipped | Yes |
| Android build and launch | Skipped | Yes |
| Avalonia templates | Skipped | 3-template matrix |
| MAUI Android packages and runtime screenshots | Skipped | Full project/page matrix, 4 shards |

## Validation

- `actionlint`
- workflow YAML parse and job-policy assertions
- shell syntax checks for both capture scripts
- repository inventory validation
- whitespace validation
- confirmed the MAUI capture script remains unchanged from `main`
