### PR TITLE
Capture the Avalonia Gallery overview

### DIFF
--- a/samples/avalonia/Gallery/MainView.fs
+++ b/samples/avalonia/Gallery/MainView.fs
@@ -152,39 +152,45 @@ module MainView =
         )
 
 
-    let view () =
+    let content () =
         Component("MainView") {
             let! model = Context.Mvu program
 
-            SingleViewApplication(
-                ScrollViewer(
-                    match model.Details with
-                    | Some(CurrentWidget page) ->
-                        AnyView(
-                            VStack(16.) {
-                                Button("Go back", GoBack)
-                                page
+            ScrollViewer(
+                match model.Details with
+                | Some(CurrentWidget page) ->
+                    AnyView(
+                        VStack(16.) {
+                            Button("Go back", GoBack)
+                            page
+                        }
+                    )
+                | _ ->
+                    AnyView(
+                        Grid() {
+                            UniformGrid(cols = 2, rows = 37) {
+                                for i in 0 .. controlNames.Length - 1 do
+                                    CardItem(controlNames[i]).onTapped(SelectControl).gridRow(i / 2)
                             }
-                        )
-                    | _ ->
-                        AnyView(
-                            Grid() {
-                                UniformGrid(cols = 2, rows = 37) {
-                                    for i in 0 .. controlNames.Length - 1 do
-                                        CardItem(controlNames[i]).onTapped(SelectControl).gridRow(i / 2)
-                                }
-                            }
-                        )
-                )
+                        }
+                    )
             )
         }
 
-    let create () =
-        let theme () =
+    let view () = SingleViewApplication(content())
+
+    let desktopView () =
+        DesktopApplication() { Window(content()).title("Fabulous Gallery").width(1024.).height(800.).icon("avares://Gallery/Assets/Icons/logo.ico") }
+
+    let theme () =
 #if PREMIUM_CONTROLS
-            StyleInclude(baseUri = null, Source = Uri("avares://Gallery/App.Premium.xaml"))
+        StyleInclude(baseUri = null, Source = Uri("avares://Gallery/App.Premium.xaml"))
 #else
-            StyleInclude(baseUri = null, Source = Uri("avares://Gallery/App.xaml"))
+        StyleInclude(baseUri = null, Source = Uri("avares://Gallery/App.xaml"))
 #endif
 
+    let create () =
         FabulousAppBuilder.Configure(theme, view)
+
+    let createDesktop () =
+        FabulousAppBuilder.Configure(theme, desktopView)

--- a/samples/avalonia/Gallery/Platform/Desktop/Program.fs
+++ b/samples/avalonia/Gallery/Platform/Desktop/Program.fs
@@ -7,7 +7,10 @@ open Gallery
 module Program =
 
     [<CompiledName "BuildAvaloniaApp">]
-    let buildAvaloniaApp () = MainWindow.create().UsePlatformDetect()
+    let buildAvaloniaApp () =
+        match Environment.GetEnvironmentVariable("FABULOUS_GALLERY_PAGE") with
+        | null -> MainWindow.create().UsePlatformDetect()
+        | _ -> MainView.createDesktop().UsePlatformDetect()
 
     [<EntryPoint; STAThread>]
     let main argv =


### PR DESCRIPTION
## Summary

- route automated desktop Gallery launches through the existing `FABULOUS_GALLERY_PAGE`-aware view
- host that view in a proper desktop application window for CI capture
- preserve the current `MainWindow` experience for ordinary desktop launches

## Why

The capture script set `FABULOUS_GALLERY_PAGE`, but the desktop entry point always launched `MainWindow`, which ignored the value and defaulted to `AcrylicPage`. As a result, the representative PR screenshot and every named main-branch Gallery capture showed the same Acrylic page.

An explicitly present capture variable now selects the automation view: an empty value renders the Gallery overview, while named values render their requested control pages. An absent variable continues to launch the normal desktop Gallery.

## Validation

- focused Gallery desktop/free-controls build, zero warnings
- `dotnet fantomas --check` on both changed F# files
- runtime smoke launch with an empty `FABULOUS_GALLERY_PAGE`
- `actionlint`
- capture script syntax check
- repository inventory validation
- whitespace validation

The PR screenshot job provides the final Xvfb-rendered overview artifact.
