### PR TITLE
Prepare Fabulous 10.0.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Release publishing now starts only for changelog changes, waits for the matching successful CI run, and no longer requests approval for ordinary builds.
+## [10.0.0] - 2026-08-24
 
 ### Added
 - Consolidate the Fabulous core, Avalonia, .NET MAUI, extensions, templates, tests, documentation, and engineering into one repository.
-- Add release-candidate package, sample, template, SourceLink, and native launch validation for Fabulous 10.
+- Add thread-safe throttled dispatch APIs and the `onReceive` component modifier ([#1130](https://github.com/fabulous-dev/Fabulous/pull/1130)).
+- Add route-based .NET MAUI navigation stacks ([#1123](https://github.com/fabulous-dev/Fabulous/pull/1123)).
+- Add Fabulous 10 architecture, migration, deployment, licensing, glossary, tutorial, and generated API-reference documentation ([#1127](https://github.com/fabulous-dev/Fabulous/pull/1127), [#1135](https://github.com/fabulous-dev/Fabulous/pull/1135)).
+- Add release-candidate validation for packages, symbols, SourceLink, public APIs, samples, templates, clean consumers, screenshots, and native application launch ([#1126](https://github.com/fabulous-dev/Fabulous/pull/1126), [#1129](https://github.com/fabulous-dev/Fabulous/pull/1129), [#1131](https://github.com/fabulous-dev/Fabulous/pull/1131)).
+- Add repository automation for issue triage and maintenance assistance ([#1146](https://github.com/fabulous-dev/Fabulous/pull/1146)).
 
 ### Changed
 - Rename the core project and assembly from `Fabulous` to `Fabulous.Core`. The NuGet package ID and F# namespaces remain `Fabulous`.
 - Build and publish all Fabulous packages and templates from one solution and release workflow.
 - Unify all Fabulous package versions on the `10.0.x` release line.
-- Target .NET 10 across the core, Avalonia, MAUI, samples, templates, and CI.
+- Target .NET 10 across the core, Avalonia, MAUI, samples, templates, and CI ([#1128](https://github.com/fabulous-dev/Fabulous/pull/1128)).
+- Upgrade the Avalonia backend to Avalonia 12 and the MAUI backend to MAUI 10 ([#1124](https://github.com/fabulous-dev/Fabulous/pull/1124), [#1132](https://github.com/fabulous-dev/Fabulous/pull/1132)).
+- Expand CI to build all Avalonia desktop samples, exercise native MAUI targets, instantiate all Avalonia template variants, and capture Gallery screenshots.
+- Publish the website, authored documentation, and generated API reference together on GitHub Pages.
+- Improve CI concurrency, dependency caching, sharding, artifact discovery, runtime readiness checks, and pull-request execution time ([#1133](https://github.com/fabulous-dev/Fabulous/pull/1133), [#1134](https://github.com/fabulous-dev/Fabulous/pull/1134), [#1139](https://github.com/fabulous-dev/Fabulous/pull/1139)).
+- Update Windows compatibility and sample APIs for .NET 10 and current MAUI behavior.
 - Remove the obsolete MAUI `MenuItem.accelerator` modifier; use `MenuFlyoutItem.keyboardAccelerators` instead.
+
+### Fixed
+- Release publishing now starts only for changelog changes, waits for the matching successful CI run, and no longer requests approval for ordinary builds.
+- Make MAUI virtualized collection updates safe when templates and source collections change ([#1125](https://github.com/fabulous-dev/Fabulous/pull/1125)).
+- Fix Android, Apple, and Windows package discovery, deployment, startup, and runtime smoke validation ([#1131](https://github.com/fabulous-dev/Fabulous/pull/1131), [#1134](https://github.com/fabulous-dev/Fabulous/pull/1134), [#1138](https://github.com/fabulous-dev/Fabulous/pull/1138)).
+- Fix Avalonia screenshot readiness and Gallery overview capture ([#1140](https://github.com/fabulous-dev/Fabulous/pull/1140)).
+- Fix .NET 10 sample and template restore, packaging, runtime identifiers, platform architecture, and generated resources.
+- Fix MAUI deprecation warnings, WinUI sample executable discovery, and website community links ([#1136](https://github.com/fabulous-dev/Fabulous/pull/1136), [#1137](https://github.com/fabulous-dev/Fabulous/pull/1137), [#1138](https://github.com/fabulous-dev/Fabulous/pull/1138)).
+- Correct the published MAUI and Avalonia deployment commands for .NET 10.
 
 ## [3.0.0-pre23] - 2025-06-05
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -8,14 +8,14 @@ The maintained [HelloWorld project](https://github.com/fabulous-dev/Fabulous/blo
 
 ```bash
 # Android APK/AAB; configure an Android signing keystore for distribution
-dotnet publish MyApp.fsproj -c Release -f net8.0-android
+dotnet publish MyApp.fsproj -c Release -f net10.0-android
 
 # iOS and Mac Catalyst require macOS, Xcode, and Apple signing profiles
-dotnet publish MyApp.fsproj -c Release -f net8.0-ios
-dotnet publish MyApp.fsproj -c Release -f net8.0-maccatalyst
+dotnet publish MyApp.fsproj -c Release -f net10.0-ios
+dotnet publish MyApp.fsproj -c Release -f net10.0-maccatalyst
 
 # Windows requires Windows, the MAUI workload, and a Windows TFM in the project
-dotnet publish MyApp.fsproj -c Release -f net8.0-windows10.0.19041.0
+dotnet publish MyApp.fsproj -c Release -f net10.0-windows10.0.19041.0
 ```
 
 Follow the platform signing and store steps in the [.NET MAUI publishing guide](https://learn.microsoft.com/dotnet/maui/deployment/). The repository's Windows support uses `FSharp.Maui.WinUICompat`; generated templates add it for the Windows target.
@@ -25,9 +25,9 @@ Follow the platform signing and store steps in the [.NET MAUI publishing guide](
 Desktop Avalonia publishes with a runtime identifier:
 
 ```bash
-dotnet publish MyApp.fsproj -c Release -f net8.0 -r linux-x64 --self-contained true
-dotnet publish MyApp.fsproj -c Release -f net8.0 -r osx-arm64 --self-contained true
-dotnet publish MyApp.fsproj -c Release -f net8.0 -r win-x64 --self-contained true
+dotnet publish MyApp.fsproj -c Release -f net10.0 -r linux-x64 --self-contained true
+dotnet publish MyApp.fsproj -c Release -f net10.0 -r osx-arm64 --self-contained true
+dotnet publish MyApp.fsproj -c Release -f net10.0 -r win-x64 --self-contained true
 ```
 
 Package the output using the operating system's normal installer format. For Avalonia Android and iOS, start from `fabulous-avalonia-multi`; build the platform host project on a machine with the corresponding workloads and signing tools. See the maintained [multi-target sample hosts](https://github.com/fabulous-dev/Fabulous/tree/main/samples/avalonia/Mvu/CounterApp/Platform) and Avalonia's [deployment documentation](https://docs.avaloniaui.net/docs/deployment/).

--- a/docs/tutorials/avalonia.md
+++ b/docs/tutorials/avalonia.md
@@ -28,7 +28,7 @@ For larger flows, start with [basic navigation](https://github.com/fabulous-dev/
 
 ```bash
 dotnet build -c Release
-dotnet publish -c Release -f net8.0 -r linux-x64 --self-contained true
+dotnet publish -c Release -f net10.0 -r linux-x64 --self-contained true
 ```
 
 Before publishing, add pure update tests and an Avalonia headless test. The repository's [TestableApp](https://github.com/fabulous-dev/Fabulous/tree/main/samples/avalonia/TestableApp) demonstrates both and captures a screenshot artifact in CI; see [testing and debugging](../guides/testing-debugging.md). Runtime identifiers and mobile hosts are covered in [deployment](../guides/deployment.md).

--- a/docs/tutorials/maui.md
+++ b/docs/tutorials/maui.md
@@ -12,8 +12,8 @@ dotnet new install Fabulous.MauiControls.Templates
 dotnet new fabulous-mauicontrols -n Counter
 cd Counter
 dotnet restore
-dotnet build -f net8.0-android
-dotnet build -f net8.0-android -t:Run
+dotnet build -f net10.0-android
+dotnet build -f net10.0-android -t:Run
 ```
 
 The generated project contains platform hosts and an `App.fs` with the application logic. Compare it with the maintained [MAUI CounterApp](https://github.com/fabulous-dev/Fabulous/blob/main/samples/maui/CounterApp/App.fs), which demonstrates model, messages, asynchronous commands, layouts, controls, events, and modifiers in one compiled file.
@@ -35,8 +35,8 @@ Build a richer application by choosing controls from the [MAUI Gallery](https://
 Run a build before deploying:
 
 ```bash
-dotnet build -c Release -f net8.0-android
-dotnet publish -c Release -f net8.0-android
+dotnet build -c Release -f net10.0-android
+dotnet publish -c Release -f net10.0-android
 ```
 
 Signing, store packaging, iOS/Mac Catalyst, and Windows commands are covered in [deployment](../guides/deployment.md). Unit-test `init` and `update` using the pattern in [testing and debugging](../guides/testing-debugging.md).

--- a/eng/monorepo/validate-doc-links.py
+++ b/eng/monorepo/validate-doc-links.py
@@ -79,6 +79,8 @@ def validate(root: Path) -> list[str]:
 
             for raw_target in LINK_RE.findall(line):
                 target = raw_target.strip().split(maxsplit=1)[0].strip("<>")
+                if "{" in target or "}" in target:
+                    continue
                 parsed = urlsplit(target)
 
                 if parsed.hostname and parsed.hostname.lower() in RETIRED_HOSTS:


### PR DESCRIPTION
## Summary

- publish the dated `10.0.0` changelog section covering the repository consolidation and all PRs merged on August 23-24
- correct the published MAUI and Avalonia commands to target .NET 10
- allow the documentation validator to ignore unresolved workflow-template link targets

## Release status

This PR is intentionally a draft. Merging the dated changelog section triggers NuGet publication after the matching main build, so it must not merge until the blockers and manual signoff in #1148 are complete.

The current main candidate is not green: [Build and test run 32764333707](https://github.com/fabulous-dev/Fabulous/actions/runs/32764333707) fails in Avalonia capture shard 3 with an ItemsRepeater/Avalonia 12 `TypeLoadException`.

Related: #1121, #1120, #1148

## Validation

- `python3 -B eng/monorepo/validate-inventory.py`
- `dotnet test Fabulous.sln -c Release` (52 passed; 31 existing warnings)
- changelog version and release-note parsing for `10.0.0`
- `python3 -B eng/monorepo/validate-doc-links.py`
- `python3 -B eng/monorepo/generate-api-reference.py --check`
- MkDocs 1.6.1 builds for authored docs and API reference
- `git diff --check`

Hugo was not installed locally, so the website build remains for Pages CI.