### PR TITLE
Align ItemsRepeater with Avalonia 12

### DIFF
--- a/src/avalonia/Fabulous.Avalonia.ItemsRepeater/Fabulous.Avalonia.ItemsRepeater.fsproj
+++ b/src/avalonia/Fabulous.Avalonia.ItemsRepeater/Fabulous.Avalonia.ItemsRepeater.fsproj
@@ -25,7 +25,7 @@
         <Compile Include="ItemsRepeater.fs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia.Controls.ItemsRepeater" VersionOverride="11.1.5" />
+        <PackageReference Include="Avalonia.Controls.ItemsRepeater" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Fabulous.Avalonia\Fabulous.Avalonia.fsproj" />


### PR DESCRIPTION
## Summary

Remove the `Avalonia.Controls.ItemsRepeater` 11.1.5 version override so the extension uses the centrally managed Avalonia 12 package.

The 11.x ItemsRepeater binary references `Avalonia.Input.GotFocusEventArgs`, which is absent under Avalonia 12.1.1 and caused Gallery capture shard 3 to crash in [run 32764333707](https://github.com/fabulous-dev/Fabulous/actions/runs/32764333707).

Tracks the release blocker in #1148.

## Validation

Not run at maintainer request; the fix will be checked by the full workflow on `main`.