### PR TITLE
Fix NuGet trusted publishing identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         id: nuget-login
         uses: NuGet/login@v1
         with:
-          user: fabulous
+          user: dsyme
       - name: Push packages
         run: dotnet nuget push "nupkgs/*" --source https://api.nuget.org/v3/index.json --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --skip-duplicate
       - name: Create GitHub release


### PR DESCRIPTION
## Summary

Use the NuGet.org username that created the Fabulous trusted-publishing policy for `NuGet/login@v1`.

The 10.0.0 release run packaged successfully but failed its OIDC exchange with HTTP 401 because `user: fabulous` did not own a matching trust policy: [run 32784937357](https://github.com/fabulous-dev/Fabulous/actions/runs/32784937357).

No packages were pushed and no tag or GitHub release was created.

## Validation

The failed workflow will be rerun after this correction merges.