### PR TITLE
Allow guarded release retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
       - main
     paths:
       - CHANGELOG.md
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing changelog version to retry
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -30,8 +36,21 @@ jobs:
           fetch-depth: 2
       - name: Detect new release section
         id: release
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           CURRENT_VERSION=$(python3 eng/monorepo/changelog.py current-version CHANGELOG.md)
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$REQUESTED_VERSION" != "$CURRENT_VERSION" ]; then
+              echo "Requested version $REQUESTED_VERSION does not match current changelog version $CURRENT_VERSION" >&2
+              exit 1
+            fi
+            python3 eng/monorepo/changelog.py validate-version CHANGELOG.md "$CURRENT_VERSION"
+            python3 eng/monorepo/changelog.py notes CHANGELOG.md "$CURRENT_VERSION" > "$RUNNER_TEMP/release-notes.md"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git show HEAD^:CHANGELOG.md > "$RUNNER_TEMP/previous-changelog.md"
           PREVIOUS_VERSION=$(python3 eng/monorepo/changelog.py current-version "$RUNNER_TEMP/previous-changelog.md")
           if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then


### PR DESCRIPTION
## Summary

Add an explicit manual retry path to the release workflow for recovery after publication failures.

Manual dispatch requires a version, verifies that it matches the current top changelog release, validates the version and release notes, then follows the same matching-CI, package, trusted-publishing, and GitHub release path.

This is needed because rerunning [the failed 10.0.0 workflow](https://github.com/fabulous-dev/Fabulous/actions/runs/32784937357) would reuse its old workflow definition and repeat the incorrect NuGet identity fixed by #1151.