### PR TITLE
Retry untagged releases on every main push

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -38,9 +38,10 @@ Trusted publishing is intentionally not exercised by pull-request CI. After the 
 NuGet packages are immutable and cannot be overwritten.
 
 1. Cancel the Release workflow before the NuGet push step whenever possible.
-2. If only some packages were published, finish publishing the same tested artifact set; do not rebuild the same version from a different commit.
-3. If a published version is defective, unlist every package at that version on NuGet.org and add a deprecation message pointing to the replacement.
-4. Mark the GitHub release as a prerelease or remove it if no package was published. Never move an existing tag to different source.
-5. Restore documentation by reverting the Pages source commit; do not edit generated Pages output.
-6. Add a changelog entry for the replacement version, rerun the complete candidate checklist, and publish a new version.
-7. Record affected package IDs, timestamps, NuGet/GitHub actions, customer impact, and the replacement version in an incident issue.
+2. If cancellation occurs before any package is published, leave the version untagged; the next `main` push retries it from the newer commit.
+3. If only some packages were published, do not reuse that version. Record the affected package IDs and prepare the next higher version.
+4. If a published version is defective, unlist every package at that version on NuGet.org and add a deprecation message pointing to the replacement.
+5. Mark the GitHub release as a prerelease or remove it if no package was published. Never move an existing tag to different source.
+6. Restore documentation by reverting the Pages source commit; do not edit generated Pages output.
+7. Add a changelog entry for the replacement version, rerun the complete candidate checklist, and publish a new version.
+8. Record affected package IDs, timestamps, NuGet/GitHub actions, customer impact, and the replacement version in an incident issue.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,11 @@ on:
   push:
     branches:
       - main
-    paths:
-      - CHANGELOG.md
   workflow_dispatch:
-    inputs:
-      version:
-        description: Existing changelog version to retry
-        required: true
-        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: true
 
 permissions:
   actions: read
@@ -27,44 +24,40 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.release.outputs.changed }}
+      pending: ${{ steps.release.outputs.pending }}
       version: ${{ steps.release.outputs.version }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - name: Detect new release section
+      - name: Detect pending release
         id: release
-        env:
-          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           CURRENT_VERSION=$(python3 eng/monorepo/changelog.py current-version CHANGELOG.md)
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            if [ "$REQUESTED_VERSION" != "$CURRENT_VERSION" ]; then
-              echo "Requested version $REQUESTED_VERSION does not match current changelog version $CURRENT_VERSION" >&2
-              exit 1
-            fi
-            python3 eng/monorepo/changelog.py validate-version CHANGELOG.md "$CURRENT_VERSION"
-            python3 eng/monorepo/changelog.py notes CHANGELOG.md "$CURRENT_VERSION" > "$RUNNER_TEMP/release-notes.md"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git show HEAD^:CHANGELOG.md > "$RUNNER_TEMP/previous-changelog.md"
-          PREVIOUS_VERSION=$(python3 eng/monorepo/changelog.py current-version "$RUNNER_TEMP/previous-changelog.md")
-          if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           python3 eng/monorepo/changelog.py validate-version CHANGELOG.md "$CURRENT_VERSION"
           python3 eng/monorepo/changelog.py notes CHANGELOG.md "$CURRENT_VERSION" > "$RUNNER_TEMP/release-notes.md"
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          set +e
+          git ls-remote --exit-code --tags origin "refs/tags/$CURRENT_VERSION" >/dev/null
+          TAG_STATUS=$?
+          set -e
+          case "$TAG_STATUS" in
+            0)
+              echo "pending=false" >> "$GITHUB_OUTPUT"
+              ;;
+            2)
+              echo "pending=true" >> "$GITHUB_OUTPUT"
+              echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unable to query tag refs from origin" >&2
+              exit "$TAG_STATUS"
+              ;;
+          esac
 
   release:
     needs: detect
-    if: needs.detect.outputs.changed == 'true'
+    if: needs.detect.outputs.pending == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for matching Build and test run
@@ -122,7 +115,7 @@ jobs:
         with:
           user: dsyme
       - name: Push packages
-        run: dotnet nuget push "nupkgs/*" --source https://api.nuget.org/v3/index.json --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --skip-duplicate
+        run: dotnet nuget push "nupkgs/*" --source https://api.nuget.org/v3/index.json --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,8 +92,9 @@ This command edits template JSON files. Use it only in a disposable checkout or 
 - CI must remain green on `main` before opening follow-up upgrade PRs.
 - Package creation runs at the end of the Linux Build and test job; downstream template and Windows consumer jobs download that artifact.
 - Avalonia headless tests capture rendered screenshots. Successful pull requests receive links to package and screenshot artifacts from the metadata-only `pr-artifacts.yml` workflow.
-- Releases are triggered by adding a new topmost `## [10.0.x] - YYYY-MM-DD` section to `CHANGELOG.md` and pushing it to `main`. Publishing begins only after the full main `Build and test` workflow succeeds, and the release workflow creates the tag after publishing succeeds.
+- Every push to `main` checks the topmost `## [10.0.x] - YYYY-MM-DD` section in `CHANGELOG.md`. If its tag does not exist, the version is pending and publishing begins only after the matching full main `Build and test` workflow succeeds. A newer push cancels the older attempt and retries from the newer commit; the release workflow creates the tag only after publishing succeeds.
 - NuGet publishing uses `NuGet/login@v1` with GitHub OIDC trusted publishing. Never add a long-lived NuGet API key.
+- If cancellation interrupts NuGet publication after only some packages are pushed, do not reuse that version. Record the partial release and prepare the next higher `10.0.x` version.
 - Do not create or push release tags without explicit authorization.
 
 ## Editing Guidelines

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ CI additionally validates formatting, package creation, Avalonia headless UI tes
 
 ## Packages and releases
 
-All Fabulous packages use the unified `10.0.x` version line and are released from [.github/workflows/release.yml](.github/workflows/release.yml). To publish, move the completed notes from `Unreleased` into a new top-level `## [10.0.x] - YYYY-MM-DD` section, add a fresh `Unreleased` section, and push the changelog change to `main`. After the full `Build and test` workflow succeeds, the release workflow publishes packages, creates the matching tag, and creates a GitHub release from that section. NuGet publishing uses GitHub OIDC trusted publishing; no long-lived NuGet API key is stored in the repository.
+All Fabulous packages use the unified `10.0.x` version line and are released from [.github/workflows/release.yml](.github/workflows/release.yml). To publish, move the completed notes from `Unreleased` into a new top-level `## [10.0.x] - YYYY-MM-DD` section, add a fresh `Unreleased` section, and push it to `main`. Every `main` push treats the top release section as pending while its matching tag is absent. After the full `Build and test` workflow succeeds, the release workflow publishes packages, creates the matching tag, and creates a GitHub release. A newer `main` push cancels an in-progress attempt and retries the untagged version from the newer commit. NuGet publishing uses GitHub OIDC trusted publishing; no long-lived NuGet API key is stored in the repository.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Make the release tag the durable publication state instead of comparing the changelog with the previous commit.

- run release detection on every `main` push
- treat the top changelog release as pending while its exact tag is absent
- cancel an older release attempt when a newer `main` commit arrives
- wait for the matching full `Build and test` run before packaging
- create the tag only through the final GitHub release step after NuGet publication
- fail closed when remote tag lookup fails
- reject duplicate package pushes so an interrupted partial publication requires the next higher version
- retain input-free manual dispatch for operational recovery

The release documentation and rollback checklist now describe the same state machine.

## Validation

- parsed `.github/workflows/release.yml` as YAML
- validated and extracted the current 10.0.0 changelog notes
- verified exact-tag lookup reports 10.0.0 pending with exit status 2
- `python3 -B eng/monorepo/validate-doc-links.py`
- `git diff --check`
- VS Code diagnostics: no errors

## Merge order

Merge this before #1154. Once #1154 lands, its `main` push will automatically retry 10.0.0 because the tag is still absent.