### PR TITLE
Fix typo in get-started.md

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,6 +1,6 @@
 # Get Started
 
-While you can write complete Fabulous applications, Fabulous can not be used independently as it does not provide any UI rendering by itself.
+While you can write complete Fabulous applications, Fabulous cannot be used independently as it does not provide any UI rendering by itself.
 
 You'll need to choose a "flavor" of Fabulous first:
 


### PR DESCRIPTION
Corrects a typo in the "choose your flavor" section of the getting-started docs.