### PR TITLE
Rename navigation item from 'Choose a backend' to 'Choose a flavor'

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,7 +10,7 @@ theme:
 
 nav:
   - Welcome: README.md
-  - Choose a backend: get-started.md
+  - Choose a flavor: get-started.md
   - Glossary: glossary.md
   - Tutorials:
     - .NET MAUI: tutorials/maui.md


### PR DESCRIPTION
Rename navigation item from "Choose a backend" to "Choose a flavor" to keep consistency with Fabulous terminology.