### PR TITLE
Fix inheritance links in Picker documentation

### DIFF
--- a/docs/api/maui/controls/picker.md
+++ b/docs/api/maui/controls/picker.md
@@ -1,6 +1,6 @@
 # Picker
 
-**Inheritance:** [Element](https://fabulous-dev.github.io/Fabulous/v2/api/controls/element/) -> [NavigableElement](https://fabulous-dev.github.io/Fabulous/v2/api/navigable-element/) -> [VisualElement](https://fabulous-dev.github.io/Fabulous/v2/api/visual-element/) -> [View](https://fabulous-dev.github.io/Fabulous/v2/api/view/)\
+**Inheritance:** [Element](https://github.com/fabulous-dev/Fabulous/blob/main/docs/api/maui/element.md) -> [NavigableElement](https://github.com/fabulous-dev/Fabulous/blob/main/docs/api/maui/navigableelement.md) -> [VisualElement](https://github.com/fabulous-dev/Fabulous/blob/main/docs/api/maui/visualelement.md) -> [View](https://github.com/fabulous-dev/Fabulous/blob/main/docs/api/maui/view.md/)\
 **Xamarin.Forms documentation:** Picker [API](https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.picker) / [Guide](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/picker)
 
 For details on how the control actually works, please refer to the [Xamarin.Forms documentation](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/picker).


### PR DESCRIPTION
Updated inheritance links to point to the correct GitHub documentation.