### PR TITLE
Fix inheritance links in SearchBar documentation

### DIFF
--- a/docs/api/maui/controls/searchbar.md
+++ b/docs/api/maui/controls/searchbar.md
@@ -1,6 +1,6 @@
 # SearchBar
 
-**Inheritance:** [Element](https://fabulous-dev.github.io/Fabulous/v2/api/controls/element/) -> [NavigableElement](https://fabulous-dev.github.io/Fabulous/v2/api/navigable-element/) -> [VisualElement](https://fabulous-dev.github.io/Fabulous/v2/api/visual-element/) -> [View](https://fabulous-dev.github.io/Fabulous/v2/api/view/) -> [InputView](https://fabulous-dev.github.io/Fabulous/v2/api/controls/input-view/)\
+**Inheritance:** [Element](https://github.com/fabulous-dev/Fabulous/blob/main/docs/api/maui/element.md) -> [NavigableElement](https://github.com/fabulous-dev/Fabulous/blob/main/docs/api/maui/navigableelement.md) -> [VisualElement](https://github.com/fabulous-dev/Fabulous/blob/main/docs/api/maui/visualelement.md) -> [View](https://github.com/fabulous-dev/Fabulous/blob/main/docs/api/maui/view.md) -> [InputView](https://github.com/fabulous-dev/Fabulous/blob/main/docs/api/maui/controls/inputview.md)\
 **Xamarin.Forms documentation:** SearchBar [API](https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.searchbar) / [Guide](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/searchbar)
 
 For details on how the control actually works, please refer to the [Xamarin.Forms documentation](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/searchbar).


### PR DESCRIPTION
Updated inheritance links to point to the correct GitHub documentation.