### PR TITLE
Fix formatting in get-started.md

### DIFF
--- a/docs/maui/get-started.md
+++ b/docs/maui/get-started.md
@@ -2,7 +2,6 @@
 
 ## Install the templates
 
-\
 To install the templates for Fabulous for .NET MAUI, run the following command:
 
 ```bash


### PR DESCRIPTION
Remove unnecessary backslash before installation command.