### PR TITLE
Add debugging instructions for Windows in Visual Studio

### DIFF
--- a/docs/tutorials/maui.md
+++ b/docs/tutorials/maui.md
@@ -27,6 +27,20 @@ The `-t:Run` target launches and deploys the app; to debug from an IDE (Visual S
 
 The generated project contains platform hosts and an `App.fs` with the application logic. Compare it with the maintained [MAUI CounterApp](https://github.com/fabulous-dev/Fabulous/blob/main/samples/maui/CounterApp/App.fs), which demonstrates model, messages, asynchronous commands, layouts, controls, events, and modifiers in one compiled file.
 
+## Debugging on Windows from Visual Studio
+
+Visual Studio has its own Solution Platform selector (the dropdown next to the `Debug/Release` configuration in the toolbar), tracked in the `.sln` file and completely independent of any `RuntimeIdentifier/Platform` set in the `.fsproj`. It defaults to `Any CPU`. Because a packaged Windows app host cannot be `Any CPU`, leaving this at the default causes deployment to fail.
+
+Therefore, before debugging on Windows in Visual Studio you shall:
+
+1) Open `Build` > `Configuration Manager`.
+ 
+Under `Active solution platform`, select `x64` — create it first if it isn't listed (`New...` > `x64`, copying settings from `Any CPU`). This is a Visual Studio / solution-file setting, not a project-file setting — it is not affected by `RuntimeIdentifier` or `Platform defaults` in the `.fsproj`, so this step is required regardless of the template version and cannot be fixed upstream in Fabulous.
+
+2) Confirm your project's row shows `x64` under Platform.
+
+Rebuild the solution (`Build` > `Rebuild Solution`), not an incremental build. Switching platforms after a prior `Any CPU` build can leave stale intermediate/output files that reproduce the same error even once the platform is set correctly. If rebuilding does not clear it, delete the `bin` and `obj` folders and rebuild again.
+
 ## Follow the data flow
 
 `init` creates the first model. A widget event dispatches a `Msg`; `update` returns the next model and any command; `view` describes the desired widget tree. `Program.statefulWithCmd init update |> Program.withView view` connects those functions. Fabulous reconciles the next widget tree with the live MAUI controls instead of rebuilding the whole native tree.


### PR DESCRIPTION
Added a section on debugging Windows applications in Visual Studio, including platform selection and rebuilding instructions.